### PR TITLE
Updating Capistrano config. options to support deployments from the pulbot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,14 +52,15 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'web-console', '>= 3.3.0'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'capistrano', '>= 3.14.1'
   gem 'capistrano-passenger'
   gem 'capistrano-rails', '~> 1.1.6'
+  gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rspec-rails'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ DEPENDENCIES
   bixby
   bootsnap (>= 1.1.0)
   cancancan
+  capistrano (>= 3.14.1)
   capistrano-passenger
   capistrano-rails (~> 1.1.6)
   capybara (>= 2.15)
@@ -344,4 +345,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
-# config valid for current version and patch releases of Capistrano
-lock "~> 3.14.1"
 
 set :application, "lib-jobs"
-set :repo_url, "git@github.com:pulibrary/lib_jobs.git"
+set :repo_url, "https://github.com/pulibrary/lib_jobs.git"
 set :branch, ENV["BRANCH"] || "main"
 
 # Default branch is :main


### PR DESCRIPTION
These changes were necessary in order to ensure that LibJobs may be deployed from Slack using the pulbot.