### PR TITLE
Adding path to crontab

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 set :output, '/opt/lib-jobs/shared/tmp/cron_log.log'
+env :PATH, ENV["PATH"]
 
 # Run at 6:05 am EST or 7:05 EDT (after the 6am staff report is generated)
 every 1.day, at: '11:05 am' do


### PR DESCRIPTION
avoids `/bin/bash: bundle: command not found` error