### PR TITLE
Remove uniqueness requirement.

### DIFF
--- a/app/jobs/absolute_ids/session_synchronize_job.rb
+++ b/app/jobs/absolute_ids/session_synchronize_job.rb
@@ -42,20 +42,6 @@ module AbsoluteIds
       raise(DuplicateBarcodeError, "The barcode #{barcode.value} is not unique")
     end
 
-    # Ensure that the indicator is unique
-    # @param barcode
-    # @param indicator
-    # @param repository
-    # @return [Array<TopContainer>]
-    def validate_unique_indicator(indicator:, repository:, container_id:)
-      top_resources = repository.search_top_containers_by(indicator: indicator)
-      top_resource_ids = top_resources.map(&:id)
-
-      (return if top_resource_ids.include?(container_id) || top_resources.empty?)
-
-      raise(DuplicateIndicatorError, "The Absolute ID #{absolute_id.label} is not unique")
-    end
-
     # Update the TopContainer
     # @param uri
     # @param barcode
@@ -81,7 +67,6 @@ module AbsoluteIds
 
       # Verify that the AbID and barcode are unique for the TopContainer
       validate_unique_barcode(barcode: barcode, repository: sync_repository, container_id: sync_container.id)
-      validate_unique_indicator(indicator: indicator, repository: sync_repository, container_id: sync_container.id)
 
       updated = sync_container.update(barcode: barcode.value, indicator: indicator, container_locations: updated_locations)
       Rails.logger.warn("Failed to update the TopContainer: #{sync_container.uri}") if updated.nil?

--- a/spec/jobs/absolute_ids/session_synchronize_job_spec.rb
+++ b/spec/jobs/absolute_ids/session_synchronize_job_spec.rb
@@ -260,29 +260,6 @@ RSpec.describe AbsoluteIds::SessionSynchronizeJob, type: :job do
       end
     end
 
-    context 'when a TopContainer has already using an existing AbID' do
-      let(:logger) { instance_double(ActiveSupport::Logger) }
-      let(:indicator_unique) { false }
-
-      before do
-        allow(logger).to receive(:warn)
-        allow(Rails).to receive(:logger).and_return(logger)
-      end
-
-      it 'fails to update the ArchivesSpace TopContainer and raises an error' do
-        described_class.perform_now(user_id: user.id, model_id: absolute_id.id)
-
-        expect(a_request(:post, "#{sync_client.base_uri}/repositories/4/top_containers/118091").with(
-          body: post_params,
-          headers: {
-            'Content-Type' => 'application/json'
-          }
-        )).not_to have_been_made
-
-        expect(logger).to have_received(:warn).with("Warning: Failed to synchronize #{absolute_id.label}: The Absolute ID #{absolute_id.label} is not unique")
-      end
-    end
-
     context 'when encountering an error updating a TopContainer' do
       let(:logger) { instance_double(ActiveSupport::Logger) }
       let(:updated) { absolute_id.reload }


### PR DESCRIPTION
AbIDs are not unique across all of ASpace, they're only unique across
streams. The application enforces that, so we can just remove ASpace
check.