### PR TITLE
Use upstream archivesspace-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-gem "archivesspace-client", github: "pulibrary/archivesspace-client", branch: "fix_login"
+gem "archivesspace-client"
 gem 'cancancan'
 gem "devise", ">= 4.6.0"
 gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/pulibrary/archivesspace-client.git
-  revision: 808b08d66b71025a331f0ba67d84b2b28be5a4ae
-  branch: fix_login
-  specs:
-    archivesspace-client (0.1.5)
-      httparty (= 0.14.0)
-      json (>= 2.0.3)
-      nokogiri (>= 1.6.8.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -56,6 +46,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    archivesspace-client (0.1.8)
+      httparty (~> 0.14)
+      json (~> 2.0)
+      nokogiri (~> 1.10)
     arel (9.0.0)
     ast (2.4.1)
     backport (1.1.2)
@@ -138,7 +132,8 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    httparty (0.14.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -163,6 +158,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
@@ -386,7 +384,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  archivesspace-client!
+  archivesspace-client
   bixby
   bootsnap (>= 1.1.0)
   cancancan
@@ -439,4 +437,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.4
+   2.2.21


### PR DESCRIPTION
We had to maintain a local fork of this gem for awhile, but the fix we
needed has since been incorporated upstream.