### PR TITLE
 Allowing finance email addresses to be configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-gem "archivesspace-client"
 gem 'cancancan'
 gem "devise", ">= 4.6.0"
 gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    archivesspace-client (0.1.8)
-      httparty (~> 0.14)
-      json (~> 2.0)
-      nokogiri (~> 1.10)
     arel (9.0.0)
     ast (2.4.1)
     backport (1.1.2)
@@ -132,15 +128,11 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    httparty (0.18.1)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
-    json (2.5.1)
     jwt (2.2.2)
     kramdown (2.3.1)
       rexml
@@ -158,9 +150,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
@@ -168,7 +157,6 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.2)
     msgpack (1.3.3)
-    multi_xml (0.6.0)
     net-ldap (0.17.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -384,7 +372,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  archivesspace-client
   bixby
   bootsnap (>= 1.1.0)
   cancancan

--- a/app/mailers/finance_mailer.rb
+++ b/app/mailers/finance_mailer.rb
@@ -2,6 +2,6 @@
 class FinanceMailer < ApplicationMailer
   def report(alma_xml_invoice_list:)
     @alma_xml_invoice_list = alma_xml_invoice_list
-    mail(to: "cac9@princeton.edu, mzelesky@princeton.edu, pdiskin@princeton.edu", subject: 'Alma to Peoplesoft Voucher Feed Results')
+    mail(to: LibJobs.config[:voucher_feed_recipients], subject: 'Alma to Peoplesoft Voucher Feed Results')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,11 +18,6 @@ module IlsApps
       OpenStruct.new(build)
     end
 
-    def archivesspace_config_for(*args)
-      build = config_for(*args)
-      LibJobs::ArchivesSpace::Configuration.new(build.to_h)
-    end
-
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,23 +1,5 @@
 ---
 defaults: &defaults
-  archivesspace:
-    source:
-      base_uri: <%= ENV["ASPACE_URL"] %>
-      username: <%= ENV["ASPACE_USER"] || 'admin' %>
-      password: <%= ENV["ASPACE_PASSWORD"] || 'secret' %>
-
-      page_size: <%= ENV["ASPACE_PAGE_SIZE"] || '50' %>
-      throttle: <%= ENV["ASPACE_THROTTLE"] || '0' %>
-      verify_ssl: <%= ENV["ASPACE_VERIFY_SSL"] && ENV["ASPACE_VERIFY_SSL"].strip.downcase == 'true' || false %>
-    sync:
-      base_uri: <%= ENV["ASPACE_URL"] %>
-      username: <%= ENV["ASPACE_USER"] || 'admin' %>
-      password: <%= ENV["ASPACE_PASSWORD"] || 'secret' %>
-
-      page_size: <%= ENV["ASPACE_PAGE_SIZE"] || '50' %>
-      throttle: <%= ENV["ASPACE_THROTTLE"] || '0' %>
-      verify_ssl: <%= ENV["ASPACE_VERIFY_SSL"] && ENV["ASPACE_VERIFY_SSL"].strip.downcase == 'true' || false %>
-
   sizes:
     global:
       'Objects': 'C'
@@ -59,15 +41,6 @@ development:
 
 test:
   <<: *defaults
-  archivesspace:
-    source:
-      username: "test"
-      password: "password"
-      base_uri: "https://aspace.test.org/staff/api"
-    sync:
-      username: "test"
-      password: "password"
-      base_uri: "https://aspace.test.org/staff/api"
 
 production:
   <<: *defaults

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,39 +1,6 @@
 ---
 defaults: &defaults
-  sizes:
-    global:
-      'Objects': 'C'
-      'BoxQ': 'L'
-      'Double Elephant size box': 'Z'
-      'Double Elephant volume': 'D'
-      'Elephant size box': 'P'
-      'Elephant volume': 'E'
-      'Folio': 'F'
-      'NBox': 'B'
-      'Ordinary': 'N'
-      'Quarto': 'Q'
-      'Small': 'S'
-    mudd:
-      'Mudd OS depth': 'DO'
-      'Mudd OS height': 'H'
-      'Mudd OS length': 'LO'
-      'Mudd OS Extra height': 'XH'
-      'Mudd OS Extra height, depth': 'XHD'
-      'Mudd ST records center': 'S'
-      'Mudd ST manuscript': 'S'
-      'Mudd ST half-manuscript': 'S'
-      'Mudd ST other': 'S'
-      'Mudd OS open': 'O'
-      'Mudd Oversize folder': 'C'
-
-  repositories:
-    classifiers:
-      'ctsn': 'cotsen'
-      'ex': 'rarebooks' # Firestone Library, Vault, Rare Books
-      'hsvm': 'mss' # Firestone, High Security Vault, Manuscripts
-      'mss': 'mss' # Firestone Library, Vault, Manuscripts
-      'rcpxm': 'mss' # ReCAP, Manuscripts
-
+  
   hmac_secret: <%= ENV["HMAC_SECRET"] || 'secret' %>
 
 development:

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,7 +1,9 @@
 ---
 defaults: &defaults
-  
+
   hmac_secret: <%= ENV["HMAC_SECRET"] || 'secret' %>
+
+  voucher_feed_recipients: "cac9@princeton.edu, mzelesky@princeton.edu, pdiskin@princeton.edu"
 
 development:
   <<: *defaults
@@ -11,6 +13,7 @@ test:
 
 production:
   <<: *defaults
+  voucher_feed_recipients: "dconte@princeton.edu, sregan@princeton.edu, dmnodine@princeton.edu, cac9@princeton.edu, mzelesky@princeton.edu, pdiskin@princeton.edu"
 
 staging:
   <<: *defaults

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,20 +6,3 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 #
-
-source_client = LibJobs::ArchivesSpace::Client.source
-Rails.logger.info("Authenticating...")
-source_client.login
-Rails.logger.info("Authenticated")
-
-Rails.logger.info("Caching repositories...")
-source_client.repositories.each do |repository|
-  Rails.logger.info("Cached repository #{repository.uri}...")
-
-  repository.top_containers.each do |top_container|
-    Rails.logger.info("Cached container #{top_container.uri}...")
-  end
-end
-
-source_client.container_profiles
-source_client.locations


### PR DESCRIPTION
fixes #213

Also removed unused configuration and database seeding that was left over from when Absolute Ids was part of lib_jobs