### PR TITLE
Changing how the distribution lines are numbered

### DIFF
--- a/app/models/peoplesoft_voucher/alma_xml_fund_list.rb
+++ b/app/models/peoplesoft_voucher/alma_xml_fund_list.rb
@@ -4,19 +4,27 @@ module PeoplesoftVoucher
   class AlmaXmlFundList
     attr_reader :fund_list
 
-    delegate :select, :count, :each, :blank?, to: :fund_list
+    delegate :select, :count, :each_with_index, :blank?, to: :fund_list
 
     def initialize(line_item:)
       @fund_list = parse_fund_list(line_item)
     end
 
     def total_local_amount
-      total = BigDecimal('0')
-      fund_list.each do |fund|
-        amount = BigDecimal(fund[:usd_amount])
-        total += amount
-      end
-      total
+      @total_local ||=
+        begin
+            total = BigDecimal('0')
+            fund_list.each do |fund|
+              amount = BigDecimal(fund[:usd_amount])
+              total += amount
+            end
+            total
+          end
+    end
+
+    def total_local_amount_str
+      @total_local_str ||= format("%.2f", total_local_amount)
+      @total_local_str
     end
 
     def total_original_amount

--- a/app/models/peoplesoft_voucher/alma_xml_invoice.rb
+++ b/app/models/peoplesoft_voucher/alma_xml_invoice.rb
@@ -88,7 +88,7 @@ module PeoplesoftVoucher
     def invoice_create_date
       @inv_create_date ||= begin
                             inv_create_date = xml_invoice.at_xpath('xmlns:invoice_ownered_entity/xmlns:creationDate').text
-                            inv_create_date.gsub(/^([0-9]{4})([0-9]{2})([0-9]{2})$/, '\1-\2-\3')
+                            inv_create_date.gsub(/^([0-9]{2}).([0-9]{2}).([0-9]{4})$/, '\3-\1-\2')
                           end
     end
 
@@ -172,6 +172,7 @@ module PeoplesoftVoucher
     end
 
     ### Reporting code is used for the entire invoice line instead of each payment
+    # rubocop:disable Metrics/MethodLength
     def parse_alma_line_item(line_item)
       line_item_hash = {}
       line_item_hash[:inv_line_number] = line_item.at_xpath('xmlns:line_number').text
@@ -179,6 +180,7 @@ module PeoplesoftVoucher
       line_item_hash[:fund_list] = PeoplesoftVoucher::AlmaXmlFundList.new(line_item: line_item)
       line_item_hash[:currencies] = line_item_hash[:fund_list].currency_codes
       line_item_hash[:total_local_amount] = line_item_hash[:fund_list].total_local_amount
+      line_item_hash[:total_local_amount_str] = line_item_hash[:fund_list].total_local_amount_str
       line_item_hash[:total_original_amount] = line_item_hash[:fund_list].total_original_amount
       line_item_hash[:inv_line_note] = line_item.at_xpath('xmlns:note')&.text
       po_info = get_alma_po_info(line_item)
@@ -188,6 +190,7 @@ module PeoplesoftVoucher
       line_item_hash[:bib_id] = po_info[:bib_id]
       line_item_hash
     end
+    # rubocop:enable Metrics/MethodLength
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/peoplesoft_voucher/alma_xml_invoice_list.rb
+++ b/app/models/peoplesoft_voucher/alma_xml_invoice_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 # access alma xml invoice list and make it accessible for processing
+require 'csv'
+
 module PeoplesoftVoucher
   class AlmaXmlInvoiceList
     attr_reader :xml_file, :invoices, :sftp_locations, :alma_sftp, :file_pattern, :input_ftp_base_dir

--- a/spec/fixtures/finance_invoice.xml
+++ b/spec/fixtures/finance_invoice.xml
@@ -398,8 +398,20 @@
             <business_unit_gl>PRINU</business_unit_gl>
             <account>1234</account>
             <deptid>44444</deptid>
-            <merchandise_amt>17.00</merchandise_amt>
+            <merchandise_amt>12.00</merchandise_amt>
             <fund_code>E9999</fund_code>
+            <program_code/>
+            <voucher_id>A1222333</voucher_id>
+          </vchr_dist_stg>
+          <vchr_dist_stg class="r">
+            <business_unit>PRINU</business_unit>
+            <voucher_line_num>1</voucher_line_num>
+            <distrib_line_num>2</distrib_line_num>
+            <business_unit_gl>PRINU</business_unit_gl>
+            <account>1234</account>
+            <deptid>44444</deptid>
+            <merchandise_amt>5.00</merchandise_amt>
+            <fund_code>E9998</fund_code>
             <program_code/>
             <voucher_id>A1222333</voucher_id>
           </vchr_dist_stg>

--- a/spec/fixtures/invoice_export_202118300518.xml
+++ b/spec/fixtures/invoice_export_202118300518.xml
@@ -84,7 +84,7 @@
       <number_of_attachments>0</number_of_attachments>
       <invoice_ownered_entity>
         <createdBy>999999999</createdBy>
-        <creationDate>20210330</creationDate>
+        <creationDate>03/30/2021</creationDate>
         <customerId>1111</customerId>
         <institutionId>2222</institutionId>
         <modifiedBy>999999999</modifiedBy>
@@ -124,11 +124,11 @@
             <fund_info>
               <amount>
                 <currency>USD</currency>
-                <sum>17</sum>
+                <sum>12</sum>
               </amount>
               <local_amount>
                 <currency>USD</currency>
-                <sum>17</sum>
+                <sum>12</sum>
               </local_amount>
               <code>E9999-Stuff-no program</code>
               <name>Library General Acquisitions</name>
@@ -139,6 +139,25 @@
               <fund_type_desc>General</fund_type_desc>
               <ledger_code>E999-STF</ledger_code>
               <ledger_name>Stuff</ledger_name>
+            </fund_info>
+            <fund_info>
+              <amount>
+                <currency>USD</currency>
+                <sum>5</sum>
+              </amount>
+              <local_amount>
+                <currency>USD</currency>
+                <sum>5</sum>
+              </local_amount>
+              <code>E9998-Stuff-no program</code>
+              <name>Library General Acquisitions</name>
+              <fiscal_period>FY-2021</fiscal_period>
+              <external_id>44444|E9998</external_id>
+              <type>ALLOCATED</type>
+              <fund_type>4</fund_type>
+              <fund_type_desc>General</fund_type_desc>
+              <ledger_code>E998-STF</ledger_code>
+              <ledger_name>Stuff1</ledger_name>
             </fund_info>
           </fund_info_list>
         </invoice_line>


### PR DESCRIPTION
We did not have an example with multiple funds for one transaction.  Change the example to have multiple and change the output