### PR TITLE
Updating the unique identifier algorithm for voucher ids

### DIFF
--- a/app/models/peoplesoft_voucher/alma_xml_invoice.rb
+++ b/app/models/peoplesoft_voucher/alma_xml_invoice.rb
@@ -16,7 +16,11 @@ module PeoplesoftVoucher
     end
 
     def voucher_id
-      @voucher_id ||= 'A' + unique_identifier[2..8]
+      @voucher_id ||= begin
+                        id_number_string = unique_identifier[2..-5]
+                        id = id_number_string.to_i
+                        "A#{id.to_s(36).rjust(7, '0')}".upcase
+                      end
       @voucher_id
     end
 

--- a/spec/fixtures/finance_invoice.xml
+++ b/spec/fixtures/finance_invoice.xml
@@ -366,7 +366,7 @@
     <transaction>
       <vchr_hdr_stg class="R">
         <business_unit>PRINU</business_unit>
-        <voucher_id>A1222333</voucher_id>
+        <voucher_id>A0K7QUIS</voucher_id>
         <voucher_style>REG</voucher_style>
         <invoice_id>PO-9999</invoice_id>
         <invoice_dt>2021-03-30</invoice_dt>
@@ -381,7 +381,7 @@
         <vchr_pymt_stg class="R">
           <business_unit>PRINU</business_unit>
           <pymnt_cnt>1</pymnt_cnt>
-          <voucher_id>A1222333</voucher_id>
+          <voucher_id>A0K7QUIS</voucher_id>
         </vchr_pymt_stg>
         <vchr_line_stg class="r">
           <business_unit>PRINU</business_unit>
@@ -389,7 +389,7 @@
           <descr>POL-999</descr>
           <merchandise_amt>17.00</merchandise_amt>
           <business_unit_gl>PRINU</business_unit_gl>
-          <voucher_id>A1222333</voucher_id>
+          <voucher_id>A0K7QUIS</voucher_id>
           <descr254_mixed>A Book we Wanted</descr254_mixed>
           <vchr_dist_stg class="r">
             <business_unit>PRINU</business_unit>
@@ -401,7 +401,7 @@
             <merchandise_amt>12.00</merchandise_amt>
             <fund_code>E9999</fund_code>
             <program_code/>
-            <voucher_id>A1222333</voucher_id>
+            <voucher_id>A0K7QUIS</voucher_id>
           </vchr_dist_stg>
           <vchr_dist_stg class="r">
             <business_unit>PRINU</business_unit>
@@ -413,7 +413,7 @@
             <merchandise_amt>5.00</merchandise_amt>
             <fund_code>E9998</fund_code>
             <program_code/>
-            <voucher_id>A1222333</voucher_id>
+            <voucher_id>A0K7QUIS</voucher_id>
           </vchr_dist_stg>
         </vchr_line_stg>
         <vchr_line_stg class="r">
@@ -422,7 +422,7 @@
           <descr>POL-888</descr>
           <merchandise_amt>107.94</merchandise_amt>
           <business_unit_gl>PRINU</business_unit_gl>
-          <voucher_id>A1222333</voucher_id>
+          <voucher_id>A0K7QUIS</voucher_id>
           <descr254_mixed>Another book we want.</descr254_mixed>
           <vchr_dist_stg class="r">
             <business_unit>PRINU</business_unit>
@@ -434,7 +434,7 @@
             <merchandise_amt>107.94</merchandise_amt>
             <fund_code>E9999</fund_code>
             <program_code/>
-            <voucher_id>A1222333</voucher_id>
+            <voucher_id>A0K7QUIS</voucher_id>
           </vchr_dist_stg>
         </vchr_line_stg>
         <vchr_line_stg class="r">
@@ -443,7 +443,7 @@
           <descr/>
           <merchandise_amt>285.00</merchandise_amt>
           <business_unit_gl>PRINU</business_unit_gl>
-          <voucher_id>A1222333</voucher_id>
+          <voucher_id>A0K7QUIS</voucher_id>
           <descr254_mixed>adjustment</descr254_mixed>
           <vchr_dist_stg class="r">
             <business_unit>PRINU</business_unit>
@@ -455,7 +455,7 @@
             <merchandise_amt>285.00</merchandise_amt>
             <fund_code>E9998</fund_code>
             <program_code/>
-            <voucher_id>A1222333</voucher_id>
+            <voucher_id>A0K7QUIS</voucher_id>
           </vchr_dist_stg>
         </vchr_line_stg>
         <vchr_line_stg class="r">
@@ -464,7 +464,7 @@
           <descr/>
           <merchandise_amt>-285.00</merchandise_amt>
           <business_unit_gl>PRINU</business_unit_gl>
-          <voucher_id>A1222333</voucher_id>
+          <voucher_id>A0K7QUIS</voucher_id>
           <descr254_mixed>adjustment</descr254_mixed>
           <vchr_dist_stg class="r">
             <business_unit>PRINU</business_unit>
@@ -476,7 +476,7 @@
             <merchandise_amt>-285.00</merchandise_amt>
             <fund_code>E9999</fund_code>
             <program_code/>
-            <voucher_id>A1222333</voucher_id>
+            <voucher_id>A0K7QUIS</voucher_id>
           </vchr_dist_stg>
         </vchr_line_stg>
       </vchr_hdr_stg>

--- a/spec/models/peoplesoft_voucher/alma_xml_invoice_list_spec.rb
+++ b/spec/models/peoplesoft_voucher/alma_xml_invoice_list_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe PeoplesoftVoucher::AlmaXmlInvoiceList, type: :model do
 
   describe "#onbase_report" do
     it "generates the correct csv" do
-      expect(alma_invoice_list.onbase_report).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A1222333\"\n")
+      expect(alma_invoice_list.onbase_report).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A0K7QUIS\"\n")
     end
   end
 
   describe "#status_report" do
     it "generates the correct csv" do
       expect(alma_invoice_list.status_report).to eq("Lib Vendor Invoice Date,Invoice No,Vendor Code,Vendor Id,Invoice Amount,Invoice Curency,Local Amount,Voucher ID,Errors\n"\
-                                                    "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A1222333,\"\"\n")
+                                                    "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A0K7QUIS,\"\"\n")
     end
   end
 
@@ -97,7 +97,7 @@ RSpec.describe PeoplesoftVoucher::AlmaXmlInvoiceList, type: :model do
     describe "#status_report" do
       it "generates the correct csv" do
         expect(alma_invoice_list.status_report).to eq("Lib Vendor Invoice Date,Invoice No,Vendor Code,Vendor Id,Invoice Amount,Invoice Curency,Local Amount,Voucher ID,Errors\n"\
-                                                      "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A1222333,\"#{invoice_errors}\"\n")
+                                                      "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A0K7QUIS,\"#{invoice_errors}\"\n")
       end
     end
   end
@@ -132,15 +132,15 @@ RSpec.describe PeoplesoftVoucher::AlmaXmlInvoiceList, type: :model do
 
     describe "#onbase_report" do
       it "generates the correct csv" do
-        expect(alma_invoice_list.onbase_report).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A1222333\"\n")
+        expect(alma_invoice_list.onbase_report).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A0K7QUIS\"\n")
       end
     end
 
     describe "#status_report" do
       it "generates the correct csv" do
         expect(alma_invoice_list.status_report).to eq("Lib Vendor Invoice Date,Invoice No,Vendor Code,Vendor Id,Invoice Amount,Invoice Curency,Local Amount,Voucher ID,Errors\n"\
-                                                      "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A1222333,\"\"\n"\
-                                                      "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A1222333,\"#{invoice_errors}\"\n")
+                                                      "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A0K7QUIS,\"\"\n"\
+                                                      "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A0K7QUIS,\"#{invoice_errors}\"\n")
       end
     end
   end

--- a/spec/models/peoplesoft_voucher/alma_xml_invoice_spec.rb
+++ b/spec/models/peoplesoft_voucher/alma_xml_invoice_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe PeoplesoftVoucher::AlmaXmlInvoice, type: :model do
 
   describe "#voucher_id" do
     it "returns the id" do
-      expect(alma_invoice.voucher_id).to eq('A1222333')
+      expect(alma_invoice.voucher_id).to eq('A0K7QUIS')
     end
 
     context "invalid invoice" do
       let(:xml_file) { File.new(Rails.root.join('spec', 'fixtures', 'invalid_invoice.xml')) }
 
       it "returns the id" do
-        expect(alma_invoice.voucher_id).to eq('A1222333')
+        expect(alma_invoice.voucher_id).to eq('A0K7QUIS')
       end
     end
   end

--- a/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
+++ b/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe PeoplesoftVoucher::VoucherFeed, type: :model do
       data_set = DataSet.last
       expect(data_set.category).to eq("VoucherFeed")
       expect(data_set.data).to eq("Lib Vendor Invoice Date,Invoice No,Vendor Code,Vendor Id,Invoice Amount,Invoice Curency,Local Amount,Voucher ID,Errors\n"\
-                                  "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A1222333,\"\"\n")
+                                  "2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A0K7QUIS,\"\"\n")
       expect(data_set.report_time).to eq(Time.zone.now.midnight)
       data = File.read("/tmp/alma_voucher_#{today}.XML")
       expect(data).to eq(File.open(Rails.root.join('spec', 'fixtures', 'finance_invoice.xml')).read)
       data = File.read("/tmp/Library Invoice Keyword Update_#{onbase_today}.csv")
-      expect(data).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A1222333\"\n")
+      expect(data).to eq("\"2021-03-30\",\"PO-9999\",\"XXX\",\"1319.05\",\"A0K7QUIS\"\n")
       File.delete("/tmp/alma_voucher_#{today}.XML")
       File.delete("/tmp/Library Invoice Keyword Update_#{onbase_today}.csv")
       confirm_email = ActionMailer::Base.deliveries.last
@@ -71,13 +71,13 @@ RSpec.describe PeoplesoftVoucher::VoucherFeed, type: :model do
                        "Invalid reporting code: must be numeric and can not be blank, Invalid invoice date: must be between four years old and one month into the future"
       expect(data_set.category).to eq("VoucherFeed")
       expect(data_set.data).to eq("Lib Vendor Invoice Date,Invoice No,Vendor Code,Vendor Id,Invoice Amount,Invoice Curency,Local Amount,Voucher ID,Errors\n"\
-                                  "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A1222333,\"#{invoice_errors}\"\n")
+                                  "1996-03-30,PO-9999,XXX,\"\",1319.05,GBP,176.66,A0K7QUIS,\"#{invoice_errors}\"\n")
       expect(data_set.report_time).to eq(Time.zone.now.midnight)
       expect(File.exist?("/tmp/alma_voucher_#{today}.XML")).to be_falsey
       expect(File.exist?("/tmp/Library Invoice Keyword Update_#{onbase_today}.csv")).to be_falsey
       confirm_email = ActionMailer::Base.deliveries.last
       expect(confirm_email.subject).to eq("Alma to Peoplesoft Voucher Feed Results")
-      expect(confirm_email.html_part.body.to_s).to include("1996-03-30</td><td>PO-9999</td><td>XXX</td><td></td><td>1319.05</td><td>GBP</td><td>176.66</td><td>A1222333</td>"\
+      expect(confirm_email.html_part.body.to_s).to include("1996-03-30</td><td>PO-9999</td><td>XXX</td><td></td><td>1319.05</td><td>GBP</td><td>176.66</td><td>A0K7QUIS</td>"\
                                                            "<td>#{invoice_errors}</td>")
       expect(confirm_email.html_part.body.to_s).to include("No invoices available to process")
     end


### PR DESCRIPTION
Change to base 36 instead of base 10 so we can include the entire alma id number

We originally specified base 32, but I realized we could include all the zeros if we did base 36.

fixes #221