### PR TITLE
Use less memory for pod

### DIFF
--- a/app/models/alma_pod_records/alma_pod_file_list.rb
+++ b/app/models/alma_pod_records/alma_pod_file_list.rb
@@ -23,7 +23,7 @@ module AlmaPodRecords
           Rails.logger.info "Downloading POD file #{entry.name}"
           filename = File.join(@input_ftp_base_dir, entry.name)
           decompressed_files = Tarball.new(sftp.file.open(filename)).contents
-          documents.concat(decompressed_files.map { |document| Nokogiri::XML(document) })
+          documents.concat(decompressed_files)
         end
       end
       documents

--- a/app/models/marc_collection.rb
+++ b/app/models/marc_collection.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Takes MARC records from Alma as IO,
+# does the necessary cleanup,
+# and then can write the results to
+# IO
+class MarcCollection
+  def initialize(document)
+    @document = document
+  end
+
+  def write(io)
+    xml = Nokogiri::XML(@document)
+    xml.children.first.default_namespace = 'http://www.loc.gov/MARC21/slim'
+    io.write(xml)
+    io
+  end
+end

--- a/config/pod.yml
+++ b/config/pod.yml
@@ -9,6 +9,7 @@ test:
   <<: *default
 
 staging: &staging
+  <<: *default
   days_to_fetch: 1
 
 production:

--- a/spec/models/alma_pod_records/alma_pod_job_spec.rb
+++ b/spec/models/alma_pod_records/alma_pod_job_spec.rb
@@ -2,18 +2,11 @@
 require 'rails_helper'
 
 RSpec.describe AlmaPodRecords::AlmaPodJob, type: :model do
-  it 'adds namespaces' do
-    document = File.open(file_fixture('marcxml_no_namespaces.xml')) { |file| Nokogiri::XML(file) }
-    list = AlmaPodRecords::AlmaPodFileList.new(documents: [document])
-    job = described_class.new(incoming_file_list: list)
-    expect(job.documents.first.xpath('//marc:collection', 'marc' => 'http://www.loc.gov/MARC21/slim').count).to eq(1)
-  end
-
   it 'sends each file to the POD' do
     pod_url = 'https://pod.stanford.edu/organizations/princeton/uploads'
     stub_request(:post, pod_url)
       .to_return(status: 201, body: '{"url":"my-url"}')
-    documents = Array.new(5) { Nokogiri::XML('<collection/>') }
+    documents = Array.new(5) { StringIO.new('<collection/>') }
     list = AlmaPodRecords::AlmaPodFileList.new(documents: documents)
     described_class.new(incoming_file_list: list, directory: Rails.root.join('tmp')).send_files
     expect(a_request(:post, pod_url)).to have_been_made.times(5)

--- a/spec/models/marc_collection_spec.rb
+++ b/spec/models/marc_collection_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MarcCollection, type: :model do
+  it 'adds namespaces' do
+    document = File.new(file_fixture('marcxml_no_namespaces.xml'))
+    io = StringIO.new
+    described_class.new(document).write(io)
+    parsed_io = Nokogiri::XML(io.string)
+    expect(parsed_io.xpath('//marc:collection', 'marc' => 'http://www.loc.gov/MARC21/slim').count).to eq(1)
+  end
+end


### PR DESCRIPTION
Previously, the pod rake task took about 4GB of RAM to process a 1.1GB MARCXML file.  With this PR, it takes about 2GB of RAM.