### PR TITLE
Allowing type in mail to be credit or payment

### DIFF
--- a/app/models/peoplesoft_bursar/credit_report.rb
+++ b/app/models/peoplesoft_bursar/credit_report.rb
@@ -7,7 +7,7 @@ module PeoplesoftBursar
     AMERICAN_DATE = "%m/%d/%Y %H:%M:%S %Z"
 
     def initialize(input_ftp_base_dir: Rails.application.config.alma_ftp.bursar_report_path, file_pattern: '\.xml$', alma_sftp: AlmaSftp.new, list: nil)
-      super(input_ftp_base_dir: input_ftp_base_dir, file_pattern: file_pattern, alma_sftp: alma_sftp, list: list)
+      super(input_ftp_base_dir: input_ftp_base_dir, file_pattern: file_pattern, alma_sftp: alma_sftp, list: list, report_type: "Credit")
     end
 
     def subject_line

--- a/app/models/peoplesoft_bursar/fine_report.rb
+++ b/app/models/peoplesoft_bursar/fine_report.rb
@@ -4,7 +4,7 @@ require 'csv'
 module PeoplesoftBursar
   class FineReport < Report
     def initialize(input_ftp_base_dir: Rails.application.config.alma_ftp.bursar_report_path, file_pattern: '\.csv$', alma_sftp: AlmaSftp.new, list: nil)
-      super(input_ftp_base_dir: input_ftp_base_dir, file_pattern: file_pattern, alma_sftp: alma_sftp, list: list)
+      super(input_ftp_base_dir: input_ftp_base_dir, file_pattern: file_pattern, alma_sftp: alma_sftp, list: list, report_type: 'Payment')
       @report_type = 'Payment'
     end
 

--- a/app/models/peoplesoft_bursar/job.rb
+++ b/app/models/peoplesoft_bursar/job.rb
@@ -16,7 +16,7 @@ module PeoplesoftBursar
       report.mark_files_as_processed
 
       FinanceMailer.bursar_report(report: report).deliver
-      data_set.data = report.body
+      data_set.data = "#{report.heading}\n#{report.body}"
       data_set.report_time = Time.zone.now
       data_set
     end

--- a/app/models/peoplesoft_bursar/report.rb
+++ b/app/models/peoplesoft_bursar/report.rb
@@ -3,14 +3,14 @@ module PeoplesoftBursar
   class Report
     attr_reader :sftp_locations, :alma_sftp, :file_pattern, :input_ftp_base_dir, :list, :department, :report_type
 
-    def initialize(input_ftp_base_dir: Rails.application.config.alma_ftp.bursar_report_path, file_pattern: '\.csv$', alma_sftp: AlmaSftp.new, list: nil)
+    def initialize(input_ftp_base_dir: Rails.application.config.alma_ftp.bursar_report_path, file_pattern: '\.csv$', alma_sftp: AlmaSftp.new, list: nil, report_type: 'Generic')
       @input_ftp_base_dir = input_ftp_base_dir
       @file_pattern = file_pattern
       @alma_sftp = alma_sftp
       @sftp_locations = []
       @list = list || download_list
       @department = '41001'
-      @report_type ||= 'Generic'
+      @report_type = report_type
     end
 
     def mark_files_as_processed
@@ -69,7 +69,7 @@ module PeoplesoftBursar
 
     def body
       return "" if list.empty?
-      "Type: Payment\nNumber of lines: #{list.size}\nTotal: #{formatted_total}"
+      "Number of lines: #{list.size}\nTotal: #{formatted_total}"
     end
 
     def start_date

--- a/spec/mailers/finance_mailer_spec.rb
+++ b/spec/mailers/finance_mailer_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe FinanceMailer, type: :mailer do
 
       it "renders the body" do
         expect(mail.html_part.body.encoded).not_to include("No file to send")
-        expect(mail.html_part.body.encoded).to include("Type: Payment")
+        expect(mail.html_part.body.encoded).to include("Type: Credit")
         expect(mail.html_part.body.encoded).to include("Number of lines: 1")
         expect(mail.html_part.body.encoded).to include("Total: -000000000005.50")
         expect(mail.html_part.body.encoded).to include("Beginning Date: #{Time.zone.today - 7.days}")

--- a/spec/models/peoplesoft_bursar/job_spec.rb
+++ b/spec/models/peoplesoft_bursar/job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PeoplesoftBursar::Job, type: :model do
         expect { expect(job.run).to be_truthy }.to change { ActionMailer::Base.deliveries.count }.by(1)
         data_set = DataSet.last
         expect(data_set.category).to eq("BursarReport")
-        expect(data_set.data).to eq("Type: Payment\nNumber of lines: 1\nTotal: -000000000005.50")
+        expect(data_set.data).to eq("Type: Credit\nNumber of lines: 1\nTotal: -000000000005.50")
         expect(data_set.report_time.to_date).to eq(Time.zone.now.to_date)
         data = File.read("/tmp/libfines.dat")
         expect(data).to eq(report.to_s)


### PR DESCRIPTION
Removes extra generic line from the email
fixes #319