### PR TITLE
Adding documents for web-staff and bursar

### DIFF
--- a/docs/peoplesoft_bursar/README.md
+++ b/docs/peoplesoft_bursar/README.md
@@ -1,0 +1,46 @@
+# PeopleSoft Bursar
+  This job moves fines and credits from Alma to student accounting.  Fines are not generated for staff and faculty.  Folks in finance have access to the end product, but other do not have access to the system.
+
+## Flow Diagrams
+
+### Fines Process
+```mermaid
+sequenceDiagram
+    Alma->>lib-sftp: run scheduled analytics report for fines (6am Princeton time daily)
+    Lib Jobs->>+lib-sftp: request list of fine csv files (Tuesday 14:30 UTC)
+    lib-sftp-->>-Lib Jobs: list of fine csv files
+    Lib Jobs->>+lib-sftp: download fine csv file(s)
+    lib-sftp-->>-Lib Jobs: fine csv file(s)
+    alt report lines exist
+    Lib Jobs->>Bursar Samba Share: Fine Report
+    Lib Jobs->>Email Server: Sends Email to Student Accounts and PUL stakeholders
+    else No report lines exist
+    Lib Jobs->>Email Server: Sends Email to PUL stakeholders
+    end
+    Lib Jobs->>lib-sftp: rename fine csv to .processed
+    alt Student Accounts received email
+    Bursar->>Bursar Samba Share: download and process Fine Report
+    Bursar->>Bursar: Fines Applied to Student Accounts
+    end
+```
+
+### Credits Process
+```mermaid
+sequenceDiagram
+    Alma->>lib-sftp: bursar export job for Credits (9pm Princeton time Daily)
+    Lib Jobs->>+lib-sftp: request list of credit xml (Thursday 14:30 UTC)
+    lib-sftp-->>-Lib Jobs: list of credit xml files
+    Lib Jobs->>+lib-sftp: download credit xml file(s)
+    lib-sftp-->>-Lib Jobs: credit xml file(s)
+    alt report lines exist
+    Lib Jobs->>Bursar Samba Share: Fine Report (Credits are negative fines)
+    Lib Jobs->>Email Server: Sends Email to Student Accounts and PUL stakeholders
+    else No report lines exist
+    Lib Jobs->>Email Server: Sends Email to PUL stakeholders
+    end
+    Lib Jobs->>lib-sftp: rename credit xml files to .processed
+    alt Student Accounts received email
+    Bursar->>Bursar Samba Share: download and process Fine Report
+    Bursar->>Bursar: Credits Applied to Student Accounts
+    end
+```

--- a/docs/web_staff/README.md
+++ b/docs/web_staff/README.md
@@ -1,0 +1,20 @@
+# Web Staff
+  This generates the staff report that is read into the library website each day to make the [staff directory](https://library.princeton.edu/staff/directory).
+
+## Flow Diagram
+
+```mermaid
+sequenceDiagram
+    PeopleSoft->>HR Reports Share: writes Department Absence Manager Report (6am Princeton time Daily)
+
+    Library Website->>+Lib Jobs: get staff updates (6:30am Princeton time Daily)
+    Lib Jobs->>HR Reports Share: read Department Absence Manager Report
+    Lib Jobs-->>-Library Website: responds with csv 
+    Library Website->>Library Website: saves csv to feeds directory
+    Library Website->>Library Website: PUL library staff Importer (every 12 hours)
+```
+
+### Key
+[get staff updates](https://github.com/pulibrary/princeton_ansible/blob/main/roles/libwww/files/get_staff_updates.sh)
+
+[PUL library staff Importer](https://library.princeton.edu/admin/structure/feeds/pul_library_staff_importer/tamper)


### PR DESCRIPTION
This is not completed work.  The fines document in the bursar is the only agreed upon diagram

Co-authored-by: Christina Chortaria <christinach@users.noreply.github.com>
Co-authored-by: Mark Zelesky <mzelesky@users.noreply.github.com>