### PR TITLE
Make it so we can run single tests

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -22,9 +22,6 @@ test:
 
 production: &production
   <<: *defaults
-  voucher_feed_recipients: <%= ENV.fetch('VOUCHER_FEED_RECIPIENTS').split(',') %>
-  peoplesoft_bursar_recipients: <%= ENV.fetch('PEOPLESOFT_BURSAR_RECIPIENTS').split(',') %>
-  peoplesoft_bursar_no_report_recipients: <%= ENV.fetch('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS').split(',') %>
-  transaction_error_feed_recipients: <%= ENV.fetch('TRANSACTION_ERROR_FEED_RECIPIENTS').split(',') %>
+  
 staging:
   <<: *production


### PR DESCRIPTION
- Having ENV.fetch without default makes it so you can't run individual tests