### PR TITLE
i355: Send an email report on nil expiration dates

### DIFF
--- a/app/mailers/alma_people_mailer.rb
+++ b/app/mailers/alma_people_mailer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AlmaPeopleMailer < ApplicationMailer
+  def error_notification(invalid_records:)
+    @invalid_records = invalid_records
+    mail(to: LibJobs.config[:alma_people_error_notification_recipients], subject: 'Peoplesoft to Alma Person loading error(s)')
+  end
+end

--- a/app/models/alma_people/alma_xml_person.rb
+++ b/app/models/alma_people/alma_xml_person.rb
@@ -8,6 +8,11 @@
 # rubocop:disable Metrics/ClassLength
 module AlmaPeople
   class AlmaXmlPerson
+    include ActiveModel::Validations
+    validates_each :person do |record, attr, value|
+      record.errors.add attr, :no_expiration_date, message: "Person doesn't have an expiration date" if value['PATRON_EXPIRATION_DATE'].blank?
+    end
+
     attr_reader :xml, :person
 
     # @param xml [XMLBuilder] builder to insert the person into

--- a/app/views/alma_people_mailer/error_notification.html.erb
+++ b/app/views/alma_people_mailer/error_notification.html.erb
@@ -1,0 +1,6 @@
+<h1>Invalid NetIDs</h1>
+<ul>
+<% @invalid_records.each do |person| %>
+  <li><%= person.person['CAMPUS_ID'] %> (<%= person.person['EMPLID'] %>): <%= person.errors.full_messages.to_sentence %></li>
+<% end %>
+</ul>

--- a/app/views/alma_people_mailer/error_notification.text.erb
+++ b/app/views/alma_people_mailer/error_notification.text.erb
@@ -1,0 +1,4 @@
+Invalid NetIDs
+<% @invalid_records.each do |person| %>
+  <%= person.person['CAMPUS_ID'] %> (<%= person.person['EMPLID'] %>): <%= person.errors.full_messages.to_sentence %>
+<% end %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   hmac_secret: <%= ENV["HMAC_SECRET"] || 'secret' %>
 
   voucher_feed_recipients: <%= ENV.fetch('VOUCHER_FEED_RECIPIENTS', 'test_user@princeton.edu').split(',') %>
+  alma_people_error_notification_recipients: <%= ENV.fetch('PEOPLE_ERROR_NOTIFICATION_RECIPIENTS', 'test_user@princeton.edu').split(',') %>
   peoplesoft_bursar_recipients: <%= ENV.fetch('PEOPLESOFT_BURSAR_RECIPIENTS', 'test_user@princeton.edu').split(',') %>
   peoplesoft_bursar_no_report_recipients: <%= ENV.fetch('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS', 'test_user@princeton.edu').split(',') %>
   transaction_error_feed_recipients: <%= ENV.fetch('TRANSACTION_ERROR_FEED_RECIPIENTS', 'test_user@princeton.edu').split(',') %>

--- a/docs/alma_people/README.md
+++ b/docs/alma_people/README.md
@@ -8,7 +8,13 @@
 sequenceDiagram
     Lib Jobs->>+Peoplesoft API Store: Requests a List of new and updated People at 12:45am UTC daily
     Peoplesoft API Store->>-Lib Jobs: Returns a JSON List of new and updated People
-    Lib Jobs->>Lib Jobs: Converts JSON to Alma Patron XML format
+    loop Each person in the JSON file
+      alt Nil expiration dates
+        Lib Jobs->>Email Server: Sends email to PUL stakeholders
+      else
+        Lib Jobs->>Lib Jobs: Converts JSON to Alma Patron XML format
+      end
+    end
     Lib Jobs->>Lib Jobs: zip Alma Patron XML
     alt Blank File    
       Lib Jobs->>Lib Jobs: Do Nothing (skip)

--- a/spec/mailers/finance_mailer_spec.rb
+++ b/spec/mailers/finance_mailer_spec.rb
@@ -3,6 +3,20 @@ require "rails_helper"
 include ActiveSupport::Testing::TimeHelpers
 
 RSpec.describe FinanceMailer, type: :mailer do
+  before do
+    # Mock environment variables for emails
+    allow(ENV).to receive(:fetch).with('VOUCHER_FEED_RECIPIENTS', "test_user@princeton.edu")
+                                 .and_return('person_1@princeton.edu,person_2@princeton.edu,person_3@princeton.edu')
+    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_RECIPIENTS', "test_user@princeton.edu")
+                                 .and_return('person_1@princeton.edu,person_2@princeton.edu')
+    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS', "test_user@princeton.edu")
+                                 .and_return('person_1@princeton.edu,person_2@princeton.edu')
+    # Not used in this test, but needed to load config file successfully
+    allow(ENV).to receive(:fetch).with('TRANSACTION_ERROR_FEED_RECIPIENTS', "test_user@princeton.edu")
+                                 .and_return('person_4@princeton.edu,person_5@princeton.edu,person_6@princeton.edu')
+    allow(ENV).to receive(:fetch).with('PEOPLE_ERROR_NOTIFICATION_RECIPIENTS', 'test_user@princeton.edu')
+                                 .and_return('person_4@princeton.edu,person_5@princeton.edu,person_6@princeton.edu')
+  end
   describe "#report" do
     let(:alma_xml_invoice_list) { instance_double("PeoplesoftVoucher::AlmaXMLInvoiceList", errors: errors, error_invoices: error_invoices, valid_invoices: valid_invoices, empty?: false) }
     let(:errors) { [] }
@@ -17,26 +31,6 @@ RSpec.describe FinanceMailer, type: :mailer do
 
     before do
       allow(alma_xml_invoice_list).to receive(:status_report).and_return("The csv status report")
-      # Mock environment variables for emails
-      allow(ENV).to receive(:fetch).with('VOUCHER_FEED_RECIPIENTS', "test_user@princeton.edu")
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu,person_3@princeton.edu')
-      allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_RECIPIENTS', "test_user@princeton.edu")
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu')
-      allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS', "test_user@princeton.edu")
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu')
-      # Not used in this test, but needed to load config file successfully
-      allow(ENV).to receive(:fetch).with('TRANSACTION_ERROR_FEED_RECIPIENTS', "test_user@princeton.edu")
-                                   .and_return('person_4@princeton.edu,person_5@princeton.edu,person_6@princeton.edu')
-      # Mock environment variables for emails
-      allow(ENV).to receive(:fetch).with('VOUCHER_FEED_RECIPIENTS')
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu,person_3@princeton.edu')
-      allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_RECIPIENTS')
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu')
-      allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS')
-                                   .and_return('person_1@princeton.edu,person_2@princeton.edu')
-      # Not used in this test, but needed to load config file successfully
-      allow(ENV).to receive(:fetch).with('TRANSACTION_ERROR_FEED_RECIPIENTS')
-                                   .and_return('person_4@princeton.edu,person_5@princeton.edu,person_6@princeton.edu')
     end
 
     it "renders the headers" do

--- a/spec/mailers/previews/alma_people_preview.rb
+++ b/spec/mailers/previews/alma_people_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# Preview all emails at http://localhost:3000/rails/mailers/alma_people
+class AlmaPeoplePreview < ActionMailer::Preview
+  def error_notification
+    xml = AlmaPeople::AlmaXmlPerson.new(xml: Nokogiri::XML::Builder.new, person: { 'CAMPUS_ID' => 'netid', 'EMPLID' => '9999999' })
+    xml.valid?
+    AlmaPeopleMailer.error_notification(invalid_records: [xml])
+  end
+end

--- a/spec/mailers/transaction_error_spec.rb
+++ b/spec/mailers/transaction_error_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe TransactionErrorMailer, type: :mailer do
 
   before do
     # Mock environment variables for emails
-    allow(ENV).to receive(:fetch).with('TRANSACTION_ERROR_FEED_RECIPIENTS')
+    allow(ENV).to receive(:fetch).with('TRANSACTION_ERROR_FEED_RECIPIENTS', "test_user@princeton.edu")
                                  .and_return('person_4@princeton.edu,person_5@princeton.edu,person_6@princeton.edu')
     # Not used in this test, but needed to load config file successfully
-    allow(ENV).to receive(:fetch).with('VOUCHER_FEED_RECIPIENTS')
+    allow(ENV).to receive(:fetch).with('VOUCHER_FEED_RECIPIENTS', "test_user@princeton.edu")
                                  .and_return('person_1@princeton.edu,person_2@princeton.edu,person_3@princeton.edu')
-    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_RECIPIENTS')
+    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_RECIPIENTS', "test_user@princeton.edu")
                                  .and_return('person_1@princeton.edu,person_2@princeton.edu')
-    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS')
+    allow(ENV).to receive(:fetch).with('PEOPLESOFT_BURSAR_NO_REPORT_RECIPIENTS', "test_user@princeton.edu")
+                                 .and_return('person_1@princeton.edu,person_2@princeton.edu')
+    allow(ENV).to receive(:fetch).with('PEOPLE_ERROR_NOTIFICATION_RECIPIENTS', "test_user@princeton.edu")
                                  .and_return('person_1@princeton.edu,person_2@princeton.edu')
   end
 

--- a/spec/models/alma_people/alma_person_feed_spec.rb
+++ b/spec/models/alma_people/alma_person_feed_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe AlmaPeople::AlmaPersonFeed, type: :model do
         expect(validate_xml(data)).to be_truthy
       end
     end
+
+    context 'invalid users' do
+      before do
+        allow_any_instance_of(AlmaPeople::AlmaXmlPerson).to receive(:valid?).and_return(false) # rubocop:disable RSpec/AnyInstance
+        allow(ENV).to receive(:fetch).and_return('person_1@princeton.edu,person_2@princeton.edu,person_3@princeton.edu')
+      end
+      it 'sends an email' do
+        expect { alma_person_feed.run }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
   end
 
   def validate_xml(data)

--- a/spec/models/alma_people/alma_xml_person_spec.rb
+++ b/spec/models/alma_people/alma_xml_person_spec.rb
@@ -110,5 +110,44 @@ RSpec.describe AlmaPeople::AlmaXmlPerson, type: :model do
         expect(builder.to_xml).to eq(alma_xml)
       end
     end
+
+    context 'null expiration date' do
+      let(:oit_person) do
+        JSON.parse('{
+          "PATRON_EXPIRATION_DATE": null,
+          "PATRON_PURGE_DATE": null,
+          "ELIGIBLE_INELIGIBLE": "E",
+          "INSERT_UPDATE_DATETIME": "2021-04-02T08:44:50.000-04:00",
+          "PVSTATCATEGORY": null,
+          "ADDRESS_END_DATE": null,
+          "PVPATRONGROUP": null,
+          "DEPTID": null,
+          "DEPT_DESCR": null,
+          "EMPLID": "999999999",
+          "PRF_OR_PRI_FIRST_NAM": "First",
+          "PRF_OR_PRI_LAST_NAME": "Last",
+          "PRF_OR_PRI_MIDDLE_NAME": "Middle",
+          "PU_BARCODE": null,
+          "CAMPUS_ID": "patron",
+          "CAMP_COUNTRY": "USA",
+          "CAMP_ADDRESS1": "Unspecified Dept - Undergrads",
+          "CAMP_ADDRESS2": "For Payroll Use Only",
+          "CAMP_ADDRESS3": null,
+          "CAMP_ADDRESS4": null,
+          "CAMP_CITY": "Princeton",
+          "CAMP_COUNTY": null,
+          "CAMP_STATE": "NJ",
+          "CAMP_POSTAL": "08544",
+          "CAMP_COUNTRY_DESCR": "United States",
+          "CAMP_STATE_DESCR": "New Jersey"
+        }')
+      end
+      it 'is marked invalid' do
+        Nokogiri::XML::Builder.new do |xml|
+          alma_person = described_class.new(xml: xml, person: oit_person)
+          expect(alma_person.valid?).to eq(false)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #355 

We will need to add the `PEOPLE_ERROR_NOTIFICATION_RECIPIENTS` envvar to the servers first, containing a comma-separated list of stakeholders to receive these messages.