### PR TITLE
For after July 4th: Revert "Remove Voucher Feed from cron schedule"

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,9 +19,9 @@ every 1.day, at: '12:45 am', roles: [:prod] do
 end
 
 # Run on production at 10:00 pm EST or 9:00 pm EDT
-# every 1.day, at: '2:00 am', roles: [:prod] do
-#  rake " lib_jobs:voucher_feed"
-# end
+every 1.day, at: '2:00 am', roles: [:prod] do
+  rake " lib_jobs:voucher_feed"
+end
 
 # Run on production at 10:30 pm EST or 9:30 pm EDT
 every 1.day, at: '2:30 am', roles: [:prod] do


### PR DESCRIPTION
Reverts pulibrary/lib_jobs#369

We should merge this to start the voucher feed again after July 4th holiday