### PR TITLE
i320: Turn on ActionMailer delivery errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
closes #320 

Raise delivery errors, so that Honeybadger can inform us when an email fails to send.