### PR TITLE
Update bundler for ruby_s ansible role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     docker:
       - image: cimg/ruby:2.7.5-browsers
         environment:
-          BUNDLER_VERSION: 2.0.1
+          BUNDLER_VERSION: 2.3.11
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,4 +445,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.27
+   2.3.11


### PR DESCRIPTION
Connected to https://github.com/pulibrary/princeton_ansible/issues/3112 - need to update bundler in order to use ruby_s role (according to the readme)