### PR TITLE
Remove variables not needed for scsb

### DIFF
--- a/config/scsb_s3.yml
+++ b/config/scsb_s3.yml
@@ -1,8 +1,6 @@
 default: &default
   scsb_auth_key: <%= ENV["SCSB_AUTH_KEY"] || 'scsb-auth-key' %>
   scsb_server: <%= ENV["SCSB_SERVER"] || 'https://test.api.com/' %>
-  scsb_s3_access_key: <%= ENV["SCSB_S3_ACCESS_KEY"] %>
-  scsb_s3_secret_access_key: <%= ENV["SCSB_S3_SECRET_ACCESS_KEY"] %>
   scsb_s3_bucket_name: <%= ENV["SCSB_S3_BUCKET_NAME"] %>
   scsb_s3_partner_access_key: <%= ["SCSB_S3_PARTNER_ACCESS_KEY"] %>
   scsb_s3_partner_secret_access_key: <%= ENV["SCSB_S3_PARTNER_SECRET_ACCESS_KEY"] %>


### PR DESCRIPTION
- Although their names in Princeton Ansible include SCSB, they are not in fact SCSB-related variables