### PR TITLE
i371: add a feature flipper for Voucher Feed job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,5 @@ gem 'icalendar', '~> 2.8'
 gem "vite_rails", "~> 3.0"
 
 gem "capistrano-yarn", "~> 2.0"
+
+gem "flipflop", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,9 @@ GEM
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
     ffi (1.15.5)
+    flipflop (2.7.1)
+      activesupport (>= 4.0)
+      terminal-table (>= 1.8)
     foreman (0.87.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -370,6 +373,8 @@ GEM
     sshkit (1.21.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     terser (1.1.13)
       execjs (>= 0.3.0, < 3)
     thor (1.2.1)
@@ -433,6 +438,7 @@ DEPENDENCIES
   devise (>= 4.6.0)
   dotenv-rails
   factory_bot_rails
+  flipflop (~> 2.7)
   foreman
   honeybadger (~> 4.0)
   icalendar (~> 2.8)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,4 +89,9 @@ class ApplicationController < ActionController::Base
   def find_user
     User.find_by(id: current_user_id, token: current_user_token)
   end
+
+  def verify_admin!
+    authenticate_user!
+    redirect_to '/users/auth/cas' unless current_user.admin?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,18 +12,7 @@ class ApplicationController < ActionController::Base
 
   def header_user_menu_item
     if current_user
-      {
-        name: current_user.email,
-        component: current_user.email,
-        href: '#',
-        children: [
-          {
-            name: 'Log Out',
-            component: 'Log Out',
-            href: destroy_user_session_path
-          }
-        ]
-      }
+      logged_in_user_menu_item
     else
       {
         name: 'Log In',
@@ -31,6 +20,29 @@ class ApplicationController < ActionController::Base
         href: new_user_session_path
       }
     end
+  end
+
+  def logged_in_user_menu_item
+    children = [
+      {
+        name: 'Log out',
+        component: 'Log out',
+        href: destroy_user_session_path
+      }
+    ]
+    if current_user.admin?
+      children << {
+        name: 'Turn jobs on and off',
+        component: 'Turn jobs on and off',
+        href: '/features'
+      }
+    end
+    {
+      name: current_user.email,
+      component: current_user.email,
+      href: '#',
+      children:
+    }
   end
 
   def library_header_menu_items

--- a/app/models/peoplesoft_voucher/voucher_feed.rb
+++ b/app/models/peoplesoft_voucher/voucher_feed.rb
@@ -22,6 +22,7 @@ module PeoplesoftVoucher
     private
 
     def handle(data_set:)
+      return log_job_is_turned_off(data_set) unless Flipflop.peoplesoft_voucher?
       build_peoplesoft_report
       build_onbase_report
       # send emails here.  The emailed file should.  Nicely formatted table in the email, one for errors & one for valid lines
@@ -67,6 +68,12 @@ module PeoplesoftVoucher
     def onbase_output_filename
       date = Time.zone.now.strftime("%Y%m%d")
       "Library Invoice Keyword Update_#{date}.csv"
+    end
+
+    def log_job_is_turned_off(data_set)
+      data_set.data = 'Voucher feed job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.'
+      data_set.report_time = Time.zone.now.midnight
+      data_set
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
 
   def admin?
     uid = email.split('@').first
-    netids.include? uid
+    netids.include?(uid) || Rails.env.development?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,4 +53,15 @@ class User < ApplicationRecord
 
     decoded_token != token
   end
+
+  def admin?
+    uid = email.split('@').first
+    netids.include? uid
+  end
+
+  private
+
+  def netids
+    @netids ||= ENV['LIB_JOBS_ADMIN_NETIDS']&.split(" ") || ""
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,12 @@ require 'zip'
 
 module IlsApps
   class Application < Rails::Application
+    config.flipflop.dashboard_access_filter = :verify_admin!
+
+    # By default, when set to `nil`, strategy loading errors are suppressed in test
+    # mode. Set to `true` to always raise errors, or `false` to always warn.
+    config.flipflop.raise_strategy_errors = false
+
     def config_for(*args)
       build = super(*args)
       OpenStruct.new(build)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 # rubocop:disable Metrics/BlockLength
 Rails.application.configure do
-  # Allow any logged-in user to access the flipflop dashboard in development
-  config.flipflop.dashboard_access_filter = lambda {
-    redirect_to '/users/auth/cas' unless user_signed_in?
-  }
-
   # By default, when set to `nil`, strategy loading errors are suppressed in test
   # mode. Set to `true` to always raise errors, or `false` to always warn.
   config.flipflop.raise_strategy_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 # rubocop:disable Metrics/BlockLength
 Rails.application.configure do
+  # Allow any logged-in user to access the flipflop dashboard in development
+  config.flipflop.dashboard_access_filter = lambda {
+    redirect_to '/users/auth/cas' unless user_signed_in?
+  }
+
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = false
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 Rails.application.configure do
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = true
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 Flipflop.configure do
   # Strategies will be used in the order listed here.
-  strategy :cookie
   strategy :active_record
   strategy :default
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :cookie
+  strategy :active_record
+  strategy :default
+
+  # Other strategies:
+  #
+  # strategy :sequel
+  # strategy :redis
+  #
+  # strategy :query_string
+  # strategy :session
+  #
+  # strategy :my_strategy do |feature|
+  #   # ... your custom code here; return true/false/nil.
+  # end
+
+  feature :peoplesoft_voucher,
+    default: true,
+    description: "Run the Peoplesoft Voucher job on a regular basis?"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  mount Flipflop::Engine => "/features"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'data_sets#index'
 

--- a/db/migrate/20230516155655_create_features.rb
+++ b/db/migrate/20230516155655_create_features.rb
@@ -1,0 +1,10 @@
+class CreateFeatures < ActiveRecord::Migration[7.0]
+  def change
+    create_table :flipflop_features do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_07_21_154522) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_16_155655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "data_sets", force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.datetime "report_time", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "report_time"
     t.string "data"
     t.string "data_file"
     t.string "category"
@@ -25,17 +25,24 @@ ActiveRecord::Schema[7.0].define(version: 2021_07_21_154522) do
     t.index ["category"], name: "index_data_sets_on_category"
   end
 
+  create_table "flipflop_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "peoplesoft_transactions", force: :cascade do |t|
     t.string "transaction_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "token"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/docs/peoplesoft_voucher/README.md
+++ b/docs/peoplesoft_voucher/README.md
@@ -24,3 +24,8 @@ sequenceDiagram
     Onbase->>Email Server: Sends Email to PUL Stakeholders
     end
 ```
+## Turning the job on and off
+
+To turn this job on or off:
+1. Go to [the flipflop dashboard](https://lib-jobs.princeton.edu/features)
+1. In the active_record column, press the on or off button

--- a/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
+++ b/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
@@ -81,5 +81,21 @@ RSpec.describe PeoplesoftVoucher::VoucherFeed, type: :model do
                                                            "<td>#{invoice_errors}</td>")
       expect(confirm_email.html_part.body.to_s).to include("No invoices available to process")
     end
+
+    context 'job is turned off' do
+      before do
+        allow(Flipflop).to receive(:peoplesoft_voucher?).and_return(false)
+      end
+      it 'logs that it is turned off' do
+        voucher_feed = described_class.new(onbase_output_base_dir: '/tmp', peoplesoft_output_base_dir: '/tmp', alma_xml_invoice_list: nil)
+        voucher_feed.run
+        data_set = DataSet.last
+        expect(data_set.data).to eq('Voucher feed job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.')
+      end
+      it 'does not email anybody' do
+        voucher_feed = described_class.new(onbase_output_base_dir: '/tmp', peoplesoft_output_base_dir: '/tmp', alma_xml_invoice_list: nil)
+        expect { voucher_feed.run }.not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,4 +66,15 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe('#admin?') do
+    it 'returns true if user is in the list of netids' do
+      subject.instance_variable_set(:@netids, %w[user user2])
+      expect(subject.admin?).to eq(true)
+    end
+    it 'returns false if user is not in the list of netids' do
+      subject.instance_variable_set(:@netids, %w[user2 user3])
+      expect(subject.admin?).to eq(false)
+    end
+  end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -6,4 +6,5 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include RequestSpecHelper, type: :request
+  config.include RequestSpecHelper, type: :system
 end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe 'header', js: true do
+  before do
+    driven_by(:selenium_chrome_headless)
+  end
+  context 'non-admin user is logged in' do
+    it 'shows a log out menu item' do
+      user = User.create(email: 'test@example.com')
+      login_as(user)
+      visit '/'
+      within('header') do
+        expect(page).to have_link('Log out', visible: false)
+      end
+    end
+  end
+  context 'admin user is logged in' do
+    it 'shows a link to the feature flipper' do
+      user = User.create(email: 'test@example.com')
+      allow(user).to receive(:admin?).and_return(true)
+      login_as(user)
+      visit '/'
+      within('header') do
+        expect(page).to have_link('Turn jobs on and off', visible: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #371 

To manually test the permissions on the flipflop dashboard:

- As `deploy@lib-jobs-staging1`, edit app_configs/lib-jobs to remove your netid from the `LIB_JOBS_ADMIN_NETIDS` line
- As `pulsys@lib-jobs-staging1`, run `sudo systemctl restart nginx`
- In your browser, confirm that you can no longer access https://lib-jobs-staging.princeton.edu/features