### PR TITLE
Added feature flipper for alma jobs

### DIFF
--- a/app/models/alma_fund_adjustment/adjustment_check.rb
+++ b/app/models/alma_fund_adjustment/adjustment_check.rb
@@ -24,6 +24,7 @@ module AlmaFundAdjustment
     private
 
     def process_file(file)
+      return log_job_is_turned_off unless Flipflop.alma_fund_adjustment?
       status = true
       data = read_file(file)
       adjustments = data.map { |row| FundAdjustment.new(row) }
@@ -44,6 +45,14 @@ module AlmaFundAdjustment
       CSVValidator.new(csv_filename: file)
                   .require_headers(['TRANSACTION_REFERENCE_NUMBER', 'TRANSACTION_NOTE', 'AMOUNT'])
       CSV.read(file, headers: true)
+    end
+
+    def log_job_is_turned_off
+      data_set = DataSet.new(category: "FundAdjustment")
+      data_set.data = 'Alma Fund Adjustment job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.'
+      data_set.report_time = Time.zone.now.midnight
+      data_set.save
+      false
     end
   end
 end

--- a/app/models/alma_invoice_status/file_converter.rb
+++ b/app/models/alma_invoice_status/file_converter.rb
@@ -21,6 +21,19 @@ module AlmaInvoiceStatus
 
     private
 
+    def handle(data_set:)
+      return log_job_is_turned_off unless Flipflop.alma_invoice_status?
+      super(data_set:)
+    end
+
+    def log_job_is_turned_off
+      data_set = DataSet.new(category: "InvoiceStatus")
+      data_set.data = 'Alma Invoice Status job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.'
+      data_set.report_time = Time.zone.now.midnight
+      data_set.save
+      data_set
+    end
+
     def process_file(path, sftp)
       query = File.open(path) { |f| StatusQuery.new(xml_io: f) }
       alma_xml = AlmaXml.new(invoices: query.invoices)

--- a/config/features.rb
+++ b/config/features.rb
@@ -19,4 +19,12 @@ Flipflop.configure do
   feature :peoplesoft_voucher,
     default: true,
     description: "Run the Peoplesoft Voucher job on a regular basis?"
+
+  feature :alma_fund_adjustment,
+    default: true,
+    description: "Run the Alma Fund Adjustment job on a regular basis?"
+
+  feature :alma_invoice_status,
+    default: true,
+    description: "Run the Alma Invoice Status job on a regular basis?"
 end

--- a/spec/models/alma_fund_adjustment/adjustment_check_spec.rb
+++ b/spec/models/alma_fund_adjustment/adjustment_check_spec.rb
@@ -48,5 +48,20 @@ RSpec.describe AlmaFundAdjustment::AdjustmentCheck, type: :model do
         expect { adjustment_check.run }.to raise_error(CSVValidator::InvalidHeadersError)
       end
     end
+    context "job is turned off" do
+      before do
+        allow(Flipflop).to receive(:alma_fund_adjustment?).and_return(false)
+      end
+      it "does not run" do
+        FileUtils.cp(Rails.root.join('spec', 'fixtures', 'fund_transactions_empty.csv'), '/tmp/test_alma_1.csv')
+        expect(adjustment_check.run).to be false
+      end
+      it "logs that it is turned off" do
+        FileUtils.cp(Rails.root.join('spec', 'fixtures', 'fund_transactions_empty.csv'), '/tmp/test_alma_1.csv')
+        adjustment_check.run
+        data_set = DataSet.last
+        expect(data_set.data).to eq("Alma Fund Adjustment job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.")
+      end
+    end
   end
 end

--- a/spec/models/alma_invoice_status/file_converter_spec.rb
+++ b/spec/models/alma_invoice_status/file_converter_spec.rb
@@ -91,5 +91,20 @@ RSpec.describe AlmaInvoiceStatus::FileConverter, type: :model do
         expect(File.open('/tmp/test_alma_1.csv.converted').read).to eq(File.open(Rails.root.join('alma_status_query_output.xml')).read)
       end
     end
+
+    context "job is turned off" do
+      before do
+        allow(Flipflop).to receive(:alma_invoice_status?).and_return(false)
+      end
+      it "logs that it is turned off" do
+        allow(sftp_session).to receive(:upload!)
+        allow(Net::SFTP).to receive(:start).and_yield(sftp_session) # start with also
+        FileUtils.touch('/tmp/test_alma_1.csv')
+
+        fund_adjustment.run
+        data_set = DataSet.last
+        expect(data_set.data).to eq("Alma Invoice Status job is typically scheduled for this time, but it is turned off.  Go to /features to turn it back on.")
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #514 

There are two outstanding accessibility issues I was unable to resolve directly, as the feature page is generated and not under our control.

1. The enabled badge's contrast isn't high enough
2. When navigating using voiceover you can turn the features on and off, but it's not clear what feature you are changing. 

Creating issues to address these in the Flipflop gem.