### PR TITLE
Download OCLC exception files

### DIFF
--- a/app/models/oclc/data_sync_exception_job.rb
+++ b/app/models/oclc/data_sync_exception_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Oclc
+  class DataSyncExceptionJob < LibJob
+    attr_reader :oclc_sftp, :input_sftp_base_dir, :file_pattern
+
+    def initialize(oclc_sftp: OclcSftp.new,
+                   input_sftp_base_dir: Rails.application.config.oclc_sftp.data_sync_exception_path)
+      super(category: "OclcDataSyncException")
+      @input_sftp_base_dir = input_sftp_base_dir
+      @file_pattern = 'BibExceptionReport.txt$'
+      @oclc_sftp = oclc_sftp
+    end
+
+    private
+
+    def handle(data_set:)
+      data_set.report_time = Time.zone.now.midnight
+      oclc_sftp.start do |sftp|
+        sftp.dir.foreach(input_sftp_base_dir) do |entry|
+          next unless /#{file_pattern}/.match?(entry.name) && date_in_range?(file_name: entry.name)
+
+          Rails.logger.debug { "Found matching pattern in file: #{entry.name}" }
+          remote_filename = File.join(input_sftp_base_dir, entry.name)
+          # ascii-8bit required for download! to succeed
+          temp_file = Tempfile.new(encoding: 'ascii-8bit')
+          sftp.download!(remote_filename, temp_file)
+        end
+      end
+      data_set
+    end
+
+    def date_in_range?(file_name:)
+      file_date_str = file_name.match(/.IN.BIB.D(\d{8})/).captures.first
+      file_date = Time.zone.parse(file_date_str)
+      today = Time.now.utc
+      file_date.between?(today - 7.days, today)
+    end
+  end
+end

--- a/config/oclc_sftp.yml
+++ b/config/oclc_sftp.yml
@@ -2,7 +2,8 @@ default: &default
   host: 'filex-m1.oclc.org'
   username: <%= ENV['OCLC_SFTP_USER'] || 'fx_pul' %>
   password: <%= ENV['OCLC_SFTP_PASSWORD'] || 'test_oclc_pass' %>
-  lc_newly_cataloged_path: '/xfer/metacoll/out/ongoing/new'
+  lc_newly_cataloged_path: '/xfer/metacoll/out/ongoing/new/'
+  data_sync_exception_path: '/xfer/metacoll/reports/'
 
 development:
   <<: *default

--- a/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20230712.T115712289.1012676.pul.non-pcc_27837389230006421_new.mrc_2.BibExceptionReport.txt
+++ b/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20230712.T115712289.1012676.pul.non-pcc_27837389230006421_new.mrc_2.BibExceptionReport.txt
@@ -1,0 +1,12 @@
+PUL_1012676_1689177432289::bib::889175|99114463063506421||1390150805|Validation Error|SEVERE|Invalid code in 1st $2 in 2nd 650.
+PUL_1012676_1689177432289::bib::889175|99114463063506421||1390150805|Validation Error|SEVERE|Invalid code in 1st $2 in 3rd 650.
+PUL_1012676_1689177432289::bib::1856787||||Data Error||crosswalk_error
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|CRITICAL|Record is sparse.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|MINOR|Invalid relationship - when Bibliographic Level (Leader/07) is equal to b, then 773 must be present.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|SEVERE|Invalid relationship - when Type of Date/Publication Status (008/06) is equal to s, then Bibliographic Level (Leader/07) must not be equal to b.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|SEVERE|Date2/Ending Date of Publication (008/11-14) is too short.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|MINOR|Invalid relationship - when Type of Cartographic Material (008/25) is equal to b, then Bibliographic Level (Leader/07) must not be equal to b.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|MINOR|Invalid relationship - when indicator 1 in 1st 045 is equal to blank, then $b in 045 must not be present.
+PUL_1012676_1689177432289::bib::1737659|9968304893506421||1390150062|Validation Error|MINOR|Invalid relationship - when $i in 246 is present, then indicator 2 in 246 must equal blank.
+PUL_1012676_1689177432289::bib::886793|99114464553506421||1390150840|Validation Error|SEVERE|Invalid code in 1st $2 in 2nd 650.
+PUL_1012676_1689177432289::bib::886793|99114464553506421||1390150840|Validation Error|SEVERE|Invalid code in 1st $2 in 3rd 650.

--- a/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20230712.T115732756.1012676.pul.non-pcc_27837389230006421_new.mrc_1.BibExceptionReport.txt
+++ b/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20230712.T115732756.1012676.pul.non-pcc_27837389230006421_new.mrc_1.BibExceptionReport.txt
@@ -1,0 +1,56 @@
+PUL_1012676_1689177452756::bib::228600|99127605741006421||1390150034|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::228600|99127605741006421||1390150034|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 336 must be present.
+PUL_1012676_1689177452756::bib::228600|99127605741006421||1390150034|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 338 must be present.
+PUL_1012676_1689177452756::bib::228600|99127605741006421||1390150034|Validation Error|MINOR|1st $c in 1st 066 indicates presence of (3 script, but (3 script is not found.
+PUL_1012676_1689177452756::bib::228600|99127605741006421||1390150034|Validation Error|SEVERE|1st $6 in 1st 260 has invalid linking data.
+PUL_1012676_1689177452756::bib::5009621||||Data Error||invalid_characters_present
+PUL_1012676_1689177452756::bib::12657080|99127121465606421|1372368663|1372368663|Processing Error||
+PUL_1012676_1689177452756::bib::6433042|99127164892406421||1390150469|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::6433042|99127164892406421||1390150469|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 336 must be present.
+PUL_1012676_1689177452756::bib::6433042|99127164892406421||1390150469|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 338 must be present.
+PUL_1012676_1689177452756::bib::6433042|99127164892406421||1390150469|Validation Error|SEVERE|1st $6 in 1st 700 has invalid linking data.
+PUL_1012676_1689177452756::bib::6433042|99127164892406421||1390150469|Validation Error|CRITICAL|Invalid relationship - when $6 in 700 is present, then 880 must be present.
+PUL_1012676_1689177452756::bib::19466335|99125529665206421||1390151308|Validation Error|SEVERE|Invalid code in 1st $2 in 1st 600.
+PUL_1012676_1689177452756::bib::19466335|99125529665206421||1390151308|Validation Error|SEVERE|Invalid code in 1st $2 in 2nd 600.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|CRITICAL|Record is sparse.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when Bibliographic Level (Leader/07) is equal to a, then 773 must be present.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when 1st $2 in 2nd 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::5243200|99127166326506421||1390150700|Validation Error|MINOR|Invalid relationship - when 1st $2 in 2nd 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|CRITICAL|Record is sparse.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when Bibliographic Level (Leader/07) is equal to a, then 773 must be present.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when 1st $2 in 2nd 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::5240561|99127166328506421||1390151393|Validation Error|MINOR|Invalid relationship - when 1st $2 in 2nd 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::12129629||||Data Error||invalid_characters_present
+PUL_1012676_1689177452756::bib::206180|99127605745306421||1390150091|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::206180|99127605745306421||1390150091|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 336 must be present.
+PUL_1012676_1689177452756::bib::206180|99127605745306421||1390150091|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 338 must be present.
+PUL_1012676_1689177452756::bib::206180|99127605745306421||1390150091|Validation Error|MINOR|1st $c in 1st 066 indicates presence of (3 script, but (3 script is not found.
+PUL_1012676_1689177452756::bib::206180|99127605745306421||1390150091|Validation Error|SEVERE|1st $6 in 1st 260 has invalid linking data.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|CRITICAL|Record is sparse.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 336 must be present.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 338 must be present.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::1605285|99127175456906421||1390151406|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|CRITICAL|Record is sparse.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|MINOR|Invalid relationship - when Bibliographic Level (Leader/07) is equal to a, then 773 must be present.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $y in 655 must not be present.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::2527306|99127172958506421||1390150126|Validation Error|MINOR|Invalid relationship - when 1st $2 in 1st 655 is equal to lcgft, then $z in 655 must not be present.
+PUL_1012676_1689177452756::bib::9759664|99127133076906421||1390149929|Validation Error|MINOR|Invalid code in Illustrations (008/18-21).
+PUL_1012676_1689177452756::bib::9759664|99127133076906421||1390149929|Validation Error|SEVERE|$b in 245 occurs too many times.
+PUL_1012676_1689177452756::bib::222335|99127605741706421||1390151350|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then Descriptive Cataloging Form (Leader/18) must equal c or i.
+PUL_1012676_1689177452756::bib::222335|99127605741706421||1390151350|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 336 must be present.
+PUL_1012676_1689177452756::bib::222335|99127605741706421||1390151350|Validation Error|MINOR|Invalid relationship - when 1st $e in 1st 040 is equal to rda, then 338 must be present.
+PUL_1012676_1689177452756::bib::222335|99127605741706421||1390151350|Validation Error|MINOR|1st $c in 1st 066 indicates presence of (3 script, but (3 script is not found.
+PUL_1012676_1689177452756::bib::222335|99127605741706421||1390151350|Validation Error|SEVERE|1st $6 in 1st 260 has invalid linking data.
+PUL_1012676_1689177452756::bib::1872908|99127174506406421||1390150841|Validation Error|MINOR|Invalid code in Illustrations (008/18-21).
+PUL_1012676_1689177452756::bib::1872908|99127174506406421||1390150841|Validation Error|SEVERE|$b in 245 occurs too many times.

--- a/spec/models/oclc/data_sync_exception_job_spec.rb
+++ b/spec/models/oclc/data_sync_exception_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Oclc::DataSyncExceptionJob, type: :model do
+  subject(:data_sync_exception_job) { described_class.new }
+  it 'can be instantiated' do
+    expect(data_sync_exception_job).to be
+  end
+  it 'knows what directory to look in' do
+    expect(data_sync_exception_job.input_sftp_base_dir).to eq('/xfer/metacoll/reports/')
+  end
+
+  it 'knows what file pattern to look for' do
+    expect(data_sync_exception_job.file_pattern).to eq('BibExceptionReport.txt$')
+  end
+
+  it 'can connect to OCLC sftp' do
+    expect(data_sync_exception_job.oclc_sftp).to be_instance_of(OclcSftp)
+  end
+
+  context 'with files on the OCLC sftp server' do
+    let(:input_sftp_base_dir) { Rails.application.config.oclc_sftp.data_sync_exception_path }
+    let(:file_full_path_one) { "#{input_sftp_base_dir}#{file_name_to_download_one}" }
+    let(:file_full_path_two) { "#{input_sftp_base_dir}#{file_name_to_download_two}" }
+    let(:file_name_to_download_one) { 'PUL-PUL.1012676.IN.BIB.D20230712.T115712289.1012676.pul.non-pcc_27837389230006421_new.mrc_2.BibExceptionReport.txt' }
+    let(:file_name_to_download_two) { 'PUL-PUL.1012676.IN.BIB.D20230712.T115732756.1012676.pul.non-pcc_27837389230006421_new.mrc_1.BibExceptionReport.txt' }
+    # too old
+    let(:file_name_to_skip_one) { 'PUL-PUL.1012676.IN.BIB.D20230526.T144121659.1012676.pul.non-pcc_26337509860006421_new.mrc_1.BibExceptionReport.txt' }
+    # different type of report
+    let(:file_name_to_skip_two) { 'PUL-PUL.1012676.IN.BIB.D20230712.T115712289.1012676.pul.non-pcc_27837389230006421_new.mrc_2.LbdExceptionReport.txt' }
+    let(:temp_file_one) { Tempfile.new(encoding: 'ascii-8bit') }
+    let(:temp_file_two) { Tempfile.new(encoding: 'ascii-8bit') }
+    let(:freeze_time) { Time.utc(2023, 7, 13) }
+    let(:sftp_entry1) { instance_double("Net::SFTP::Protocol::V01::Name", name: file_name_to_download_one) }
+    let(:sftp_entry2) { instance_double("Net::SFTP::Protocol::V01::Name", name: file_name_to_skip_one) }
+    let(:sftp_entry3) { instance_double("Net::SFTP::Protocol::V01::Name", name: file_name_to_skip_two) }
+    let(:sftp_entry4) { instance_double("Net::SFTP::Protocol::V01::Name", name: file_name_to_download_two) }
+    let(:sftp_session) { instance_double("Net::SFTP::Session", dir: sftp_dir) }
+    let(:sftp_dir) { instance_double("Net::SFTP::Operations::Dir") }
+    around do |example|
+      Timecop.freeze(freeze_time) do
+        example.run
+      end
+    end
+
+    before do
+      allow(Tempfile).to receive(:new).and_return(temp_file_one, temp_file_two)
+      allow(sftp_dir).to receive(:foreach).and_yield(sftp_entry1).and_yield(sftp_entry2).and_yield(sftp_entry3).and_yield(sftp_entry4)
+      allow(sftp_session).to receive(:download!).with(file_full_path_one, temp_file_one)
+      allow(sftp_session).to receive(:download!).with(file_full_path_two, temp_file_two)
+      allow(Net::SFTP).to receive(:start).and_yield(sftp_session)
+    end
+
+    it 'downloads only the relevant files' do
+      expect(data_sync_exception_job.run).to be_truthy
+      expect(sftp_session).to have_received(:download!).with(file_full_path_one, temp_file_one)
+      expect(sftp_session).to have_received(:download!).with(file_full_path_two, temp_file_two)
+    end
+  end
+end


### PR DESCRIPTION
Note that this writes the files from OCLC to temp files that can be passed along to the next class for processing, and will then be cleaned up by the ruby garbage collection process. 

Closes #579