### PR TITLE
Upload new marc files to alma sftp

### DIFF
--- a/app/models/oclc/data_sync_exception_job.rb
+++ b/app/models/oclc/data_sync_exception_job.rb
@@ -2,20 +2,44 @@
 
 module Oclc
   class DataSyncExceptionJob < LibJob
-    attr_reader :oclc_sftp, :input_sftp_base_dir, :file_pattern
+    attr_reader :oclc_sftp, :alma_sftp, :input_sftp_base_dir, :output_sftp_base_dir, :file_pattern, :working_file_directory
 
     def initialize(oclc_sftp: OclcSftp.new,
-                   input_sftp_base_dir: Rails.application.config.oclc_sftp.data_sync_exception_path)
+                   alma_sftp: AlmaSftp.new,
+                   input_sftp_base_dir: Rails.application.config.oclc_sftp.exceptions_input_path,
+                   output_sftp_base_dir: Rails.application.config.oclc_sftp.exceptions_output_path,
+                   working_file_directory: Rails.application.config.oclc_sftp.exceptions_working_directory)
       super(category: "OclcDataSyncException")
       @input_sftp_base_dir = input_sftp_base_dir
+      @output_sftp_base_dir = output_sftp_base_dir
       @file_pattern = 'BibExceptionReport.txt$'
       @oclc_sftp = oclc_sftp
+      @alma_sftp = alma_sftp
+      @working_file_directory = working_file_directory
+    end
+
+    def upload_files_to_alma_sftp(working_file_names:)
+      alma_sftp.start do |sftp|
+        working_file_names.each do |working_file_name|
+          source_file_path = File.join(working_file_directory, working_file_name)
+          destination_file_path = File.join(output_sftp_base_dir, working_file_name)
+          sftp.upload!(source_file_path, destination_file_path)
+          Rails.logger.debug { "Uploaded source file: #{source_file_path} to sftp path: #{destination_file_path}" }
+        end
+      end
     end
 
     private
 
     def handle(data_set:)
       data_set.report_time = Time.zone.now.midnight
+      working_file_names = process_files_from_oclc
+      upload_files_to_alma_sftp(working_file_names:)
+      data_set
+    end
+
+    def process_files_from_oclc
+      working_file_names = []
       oclc_sftp.start do |sftp|
         sftp.dir.foreach(input_sftp_base_dir) do |entry|
           next unless /#{file_pattern}/.match?(entry.name) && date_in_range?(file_name: entry.name)
@@ -25,10 +49,11 @@ module Oclc
           # ascii-8bit required for download! to succeed
           temp_file = Tempfile.new(encoding: 'ascii-8bit')
           sftp.download!(remote_filename, temp_file)
-          DataSyncExceptionFile.new(temp_file:).process
+          working_file_name = DataSyncExceptionFile.new(temp_file:).process
+          working_file_names << working_file_name
         end
       end
-      data_set
+      working_file_names
     end
 
     def date_in_range?(file_name:)

--- a/config/oclc_sftp.yml
+++ b/config/oclc_sftp.yml
@@ -3,16 +3,20 @@ default: &default
   username: <%= ENV['OCLC_SFTP_USER'] || 'fx_pul' %>
   password: <%= ENV['OCLC_SFTP_PASSWORD'] || 'test_oclc_pass' %>
   lc_newly_cataloged_path: '/xfer/metacoll/out/ongoing/new/'
-  data_sync_exception_path: '/xfer/metacoll/reports/'
   max_records_per_file: 20_000
+  exceptions_input_path: '/xfer/metacoll/reports/'
+  exceptions_working_directory: '/tmp/datasync_processing/exceptions'
+  exceptions_output_path: '/alma/datasync_processing'
 
 development:
   <<: *default
+  exceptions_working_directory: 'tmp/datasync_processing/exceptions'
 
 test:
   <<: *default
   host: 'localhost2'
   max_records_per_file: 7
+  exceptions_working_directory: 'spec/fixtures/oclc/exceptions'
 
 staging: &staging
   <<: *default

--- a/lib/tasks/lib_jobs.rake
+++ b/lib/tasks/lib_jobs.rake
@@ -99,9 +99,10 @@ namespace :lib_jobs do
     person_feed_dir = ENV["ALMA_PERSON_FEED_OUTPUT_DIR"] || '/tmp'
     pod_dir = Rails.application.config.pod.pod_record_path
     fund_adjustment_dir = Rails.application.config.peoplesoft.fund_adjustment_converted_path
+    oclc_working_files_dir = Rails.application.config.oclc_sftp.exceptions_working_directory
 
     # Production directories
-    directories = ['/tmp', person_feed_dir, pod_dir, fund_adjustment_dir].uniq
+    directories = ['/tmp', person_feed_dir, pod_dir, fund_adjustment_dir, oclc_working_files_dir].uniq
     # Directory for testing
     # directories = ['./tmp']
     directories.each do |dir_path|
@@ -131,6 +132,12 @@ namespace :lib_jobs do
   desc "process newly cataloged records from OCLC and create CSVs to send to selectors"
   task process_newly_cataloged_records: [:environment] do
     job = Oclc::NewlyCatalogedJob.new
+    job.run
+  end
+
+  desc "download data sync exceptions from oclc_sftp, process, and upload to lib-sftp"
+  task process_data_sync_exceptions: [:environment] do
+    job = Oclc::DataSyncExceptionJob.new
     job.run
   end
 end

--- a/spec/models/oclc/data_sync_exception_file_spec.rb
+++ b/spec/models/oclc/data_sync_exception_file_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Oclc::DataSyncExceptionFile, type: :model do
   let(:exception_file) { described_class.new(temp_file:) }
   let(:freeze_time) { Time.utc(2023, 7, 13, 10, 30, 5) }
   let(:oclc_fixture_file_path) { 'spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20230712.T115732756.1012676.pul.non-pcc_27837389230006421_new.mrc_1.BibExceptionReport.txt' }
-  let(:new_file_for_alma_path_1) { 'spec/fixtures/oclc/datasync_errors_20230713_103005_1.mrc' }
-  let(:new_file_for_alma_path_2) { 'spec/fixtures/oclc/datasync_errors_20230713_103005_2.mrc' }
+  let(:new_file_for_alma_path_1) { 'spec/fixtures/oclc/exceptions/datasync_errors_20230713_103005_1.mrc' }
+  let(:new_file_for_alma_path_2) { 'spec/fixtures/oclc/exceptions/datasync_errors_20230713_103005_2.mrc' }
   it 'can be instantiated with a temp_file and new file for alma' do
     expect(described_class.new(temp_file:)).to be
     expect(exception_file.temp_file).to be_an_instance_of(Tempfile)


### PR DESCRIPTION
Currently, if they process too quickly, they end up having the same name and overwriting each other (at least I think that's why it's uploading the same file name twice on staging).

Connected to #581