### PR TITLE
I564 email newly cataloged csvs

### DIFF
--- a/app/mailers/newly_cataloged_mailer.rb
+++ b/app/mailers/newly_cataloged_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class NewlyCatalogedMailer < ApplicationMailer
+  def report(selector:, file_path:)
+    week_string = Time.now.utc.strftime('%B %e, %Y')
+    @subject = "LC Slips for the week of #{week_string}"
+    file_name = Pathname.new(file_path).basename.to_s
+    attachments[file_name] = File.read(file_path)
+    mail(subject: @subject,
+         cc: 'pdiskin@princeton.edu',
+         to: selector.email)
+  end
+end

--- a/app/models/oclc/newly_cataloged_job.rb
+++ b/app/models/oclc/newly_cataloged_job.rb
@@ -17,10 +17,17 @@ module Oclc
 
     def handle(data_set:)
       create_csvs_for_selectors
-
       report_downloader.run
-
+      email_csvs_to_selectors
       data_set
+    end
+
+    def email_csvs_to_selectors
+      selectors_config.each do |selector_config|
+        selector_csv = SelectorCSV.new(selector_config:)
+        selector = Selector.new(selector_config:)
+        NewlyCatalogedMailer.report(selector:, file_path: selector_csv.file_path).deliver
+      end
     end
 
     def create_csvs_for_selectors

--- a/app/models/oclc/selector.rb
+++ b/app/models/oclc/selector.rb
@@ -11,6 +11,10 @@ module Oclc
       selector_config.keys.first.to_s
     end
 
+    def email
+      selector_config[selector_key][:email]
+    end
+
     def call_number_ranges
       selector_config[selector_key][:classes]
     end

--- a/app/views/newly_cataloged_mailer/report.html.erb
+++ b/app/views/newly_cataloged_mailer/report.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @subject %></h1>
+<p>Newly cataloged records from the Library of Congress.</p>
+<p>The attached CSV is comma-delimited, with UTF-8 encoding.</p>
+<p>In order for Excel to display it properly, you may need to import it and mark the ISBN field as text.</p>
+<p>To stop receiving these emails, please contact the DACS development team.</p>

--- a/app/views/newly_cataloged_mailer/report.text.erb
+++ b/app/views/newly_cataloged_mailer/report.text.erb
@@ -1,0 +1,9 @@
+<%= @subject %>
+
+Newly cataloged records from the Library of Congress.
+
+The attached CSV is comma-delimited, with UTF-8 encoding.
+
+In order for Excel to display it properly, you may need to import it and mark the ISBN field as text.
+
+To stop receiving these emails, please contact the DACS development team.

--- a/config/newly_cataloged.yml
+++ b/config/newly_cataloged.yml
@@ -2,6 +2,7 @@ default: &default
   selector_csv_path: '/tmp/oclc/'
   selectors:
     - bordelon:
+        email: bordelon@princeton.edu
         classes:
         - class: G
           low_num: 154.9
@@ -111,6 +112,7 @@ default: &default
         subjects:
         - economic aspects
     - darrington:
+        email: jdarring@princeton.edu
         classes:
         - class: J
           low_num: 0

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -43,6 +43,11 @@ every 1.day, at: '1:00 pm', roles: [:prod] do # The server is in UTC, so this is
   rake " lib_jobs:renew_alma_requests"
 end
 
+# Run on production at 7am EST or 6am EDT
+every :monday, at: '11:00 am', roles: [:prod] do
+  rake "lib_jobs:process_newly_cataloged_records"
+end
+
 # Run on production Tuesday at 10:30am EST or 11:30am EDT (after the records are published on Sunday)
 every :tuesday, at: '2:30 pm', roles: [:prod] do # The server is in UTC, so this is 14:30 UTC
   rake "lib_jobs:process_bursar_fines"

--- a/spec/mailers/newly_cataloged_mailer_spec.rb
+++ b/spec/mailers/newly_cataloged_mailer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe NewlyCatalogedMailer, type: :mailer do
+  describe "#report" do
+    let(:first_selector_config) { Rails.application.config.newly_cataloged.selectors[0] }
+    let(:selector) { Oclc::Selector.new(selector_config: first_selector_config) }
+    let(:file_path) { 'spec/fixtures/oclc/example_csv_for_selector.csv' }
+    let(:mail) { described_class.report(selector:, file_path:) }
+    let(:freeze_time) { Time.utc(2023, 7, 13) }
+
+    around do |example|
+      Timecop.freeze(freeze_time) do
+        example.run
+      end
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("LC Slips for the week of July 13, 2023")
+      expect(mail.to).to eq(['bordelon@princeton.edu'])
+      expect(mail.cc).to eq(['pdiskin@princeton.edu'])
+      expect(mail.from).to eq(["lib-jobs@princeton.edu"])
+      expect(mail.attachments.first.filename).to eq('example_csv_for_selector.csv')
+    end
+  end
+end

--- a/spec/models/oclc/newly_cataloged_job_spec.rb
+++ b/spec/models/oclc/newly_cataloged_job_spec.rb
@@ -64,4 +64,9 @@ RSpec.describe Oclc::NewlyCatalogedJob, type: :model do
     csv_file_two = CSV.read(new_csv_path_2)
     expect(csv_file_two.length).to eq(38)
   end
+
+  it 'emails the csv to the selectors' do
+    expect(NewlyCatalogedMailer).to receive(:report).twice.and_call_original
+    newly_cataloged_job.run
+  end
 end

--- a/spec/models/oclc/selector_spec.rb
+++ b/spec/models/oclc/selector_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Oclc::Selector, type: :model do
     expect(second_selector.name).to eq('darrington')
   end
 
+  it 'has an email' do
+    expect(first_selector.email).to eq('bordelon@princeton.edu')
+    expect(second_selector.email).to eq('jdarring@princeton.edu')
+  end
+
   it 'has an array of call numbers ranges' do
     expect(first_selector.call_number_ranges).to match_array([{ class: "G", low_num: 154.9, high_num: 155.8 },
                                                               { class: "G", low_num: 156.5, high_num: 156.599 }, { class: "GE", low_num: 125, high_num: 125 },


### PR DESCRIPTION
Emails CSVs of books that have recently been cataloged by the Library of Congress to selectors for whom those books are relevant. Creates the CSVs and emails them weekly.

Connected to #564