### PR TITLE
Add data to data_set for NewlyCatalogedJob

### DIFF
--- a/spec/models/oclc/newly_cataloged_job_spec.rb
+++ b/spec/models/oclc/newly_cataloged_job_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe Oclc::NewlyCatalogedJob, type: :model do
     expect(File.exist?(new_csv_path_2)).to be true
   end
 
+  it 'records data to display in the UI' do
+    newly_cataloged_job.run
+    data_set = DataSet.last
+    expect(data_set.report_time).to eq(freeze_time)
+    expect(data_set.data).to eq("Files created and emailed to selectors: spec/fixtures/oclc/2023-07-12-newly-cataloged-by-lc-bordelon.csv," \
+      " spec/fixtures/oclc/2023-07-12-newly-cataloged-by-lc-darrington.csv")
+  end
+
   it 'puts data in the csv file for each selector' do
     newly_cataloged_job.run
     csv_file_one = CSV.read(new_csv_path_1)


### PR DESCRIPTION
Did not add a data_file, because the job creates separate data files for each selector. Currently just records the list of files that have been sent to selectors. These files will be deleted after a week, since they are not needed long term (they're included in the file cleanup job).

Connected to #604

