### PR TITLE
Update Gemfile.lock to remove tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GIT
   remote: https://github.com/voormedia/flipflop.git
   revision: 0d70d8e33483a9c0282ed8d6bca9c5ccd61e61e8
   ref: 0d70d8e33483a9c0282ed8d6bca9c5ccd61e61e8
-  tag: v0.9.0
   specs:
     flipflop (2.7.1)
       activesupport (>= 4.0)


### PR DESCRIPTION
- Not sure how the tag got in there, but it is not the tag we want

## How I got this commit
1. Removed whole stanza in Gemfile.lock for Flipflop
2. Ran `bundle install` locally
3. Re-generated Gemfile.lock did not include the `tag: v0.9.0` line