### PR TITLE
Prefer URI().open over URI.open()

### DIFF
--- a/app/models/web_events/events_feed_generator.rb
+++ b/app/models/web_events/events_feed_generator.rb
@@ -9,7 +9,7 @@ class WebEvents::EventsFeedGenerator < LibJob
   end
 
   def events
-    @events = URI.open(WebEvents::LibcalUrl.new.to_s) do |file|
+    @events = URI(WebEvents::LibcalUrl.new.to_s).open do |file|
       raw_events = Icalendar::Calendar.parse(file).first.events
       raw_events.map { |event| WebEvents::Event.new(event) }
     end


### PR DESCRIPTION
Closes https://github.com/pulibrary/lib_jobs/security/code-scanning/1

This URL is not user-controlled (it's generated based on the yaml configs), so I don't consider us vulnerable at the moment.  This is more a matter of best practice.