### PR TITLE
Upgrade bundler to match production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     docker:
       - image: cimg/ruby:3.1.2-browsers
         environment:
-          BUNDLER_VERSION: 2.3.11
+          BUNDLER_VERSION: 2.5.6
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,8 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     nio4r (2.7.0)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     omniauth (1.9.2)
@@ -524,6 +526,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -587,4 +590,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.3.26
+   2.5.6


### PR DESCRIPTION
This is not required for deployment to work, but I like keeping the application bundler aligned with the one in production.

Had to upgrade bundler to resolve #663
See also pulibrary/princeton_ansible#4685