### PR TITLE
Allow large files to process without running out of memory

### DIFF
--- a/app/models/alma_submit_collection/marc_file_processor.rb
+++ b/app/models/alma_submit_collection/marc_file_processor.rb
@@ -8,9 +8,10 @@ module AlmaSubmitCollection
 
     def initialize(file:)
       @records_processed = 0
-      normalized_records = StringIO.new
-      MarcCollection.new(file).write(normalized_records)
-      @reader = MARC::XMLReader.new(normalized_records.reopen(normalized_records.string, 'r'), parser: "nokogiri")
+      Tempfile.create do |normalized_records|
+        MarcCollection.new(file).write(normalized_records)
+        @reader = MARC::XMLReader.new(normalized_records.path, parser: "nokogiri")
+      end
       @writer = MarcS3Writer.new(records_per_file: 10_000)
       @constituent_writer = MarcS3Writer.new(records_per_file: 1_000, file_type: 'constituent')
     end

--- a/app/models/marc_collection.rb
+++ b/app/models/marc_collection.rb
@@ -11,10 +11,22 @@ class MarcCollection
   end
 
   def write(io)
-    xml = Nokogiri::XML(@document)
-    xml.children.first.default_namespace = 'http://www.loc.gov/MARC21/slim'
-    io.write(xml)
+    parser = Nokogiri::XML::SAX::Parser.new(MarcCollectionDocumentCallbacks.new(io))
+    io.write "<?xml version=\"1.0\"?>\n"
+    parser.parse document
+
     io.close
     io
+  end
+
+  # An alternative initializer, if you just have a
+  # single record without the MARCXML namespace,
+  # as you might when getting a response from the
+  # Alma API
+  def self.from_record_string(string)
+    document = Tempfile.new
+    document.write "<collection>#{string}</collection>"
+    document.rewind
+    MarcCollection.new document
   end
 end

--- a/app/models/marc_collection_document_callbacks.rb
+++ b/app/models/marc_collection_document_callbacks.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+# This class is responsible for defining the callbacks that
+# a Nokogiri SAX parser must call when it encounters certain
+# events within a MarcXML document from Alma
+class MarcCollectionDocumentCallbacks < Nokogiri::XML::SAX::Document
+  def initialize(io)
+    super()
+    @io = io
+  end
+
+  # Write the opening tag for an element
+  def start_element(name, attrs = [])
+    # If this is the root <collection> node, and it doesn't already
+    # have the required MARC namespace, add it
+    attrs << ['xmlns', 'http://www.loc.gov/MARC21/slim'] if name == 'collection' && attrs.none? { |attr| attr[0] == 'xmlns' }
+    attr_strings = attrs.map { |attr| "#{attr[0]}=\"#{attr[1]}\"" }
+    @io.write('<')
+    @io.write(name)
+    if attr_strings.any?
+      @io.write(' ')
+      @io.write attr_strings.join(' ')
+    end
+    @io.write('>')
+  end
+
+  # Write any text that can be found in an open tag
+  def characters(string)
+    @io.write string.encode(xml: :text)
+  end
+
+  # Write the closing tag for an element
+  def end_element(name)
+    @io.write "</#{name}>"
+  end
+
+    private
+
+  def valid_marcxml_tag?(tag)
+    %w[record collection leader controlfield datafield subfield].include? tag
+  end
+end

--- a/spec/models/alma_pod_records/alma_pod_job_spec.rb
+++ b/spec/models/alma_pod_records/alma_pod_job_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AlmaPodRecords::AlmaPodJob, type: :model do
         expect(File.exist?(zipped_file_path)).to be true
         expect(File.extname(zipped_file_path)).to eq('.gz')
         `gunzip #{zipped_file_path}`
-        expect(File.read(file_path)).to eq("<?xml version=\"1.0\"?>\n<collection xmlns=\"http://www.loc.gov/MARC21/slim\"/>\n")
+        expect(File.read(file_path)).to eq("<?xml version=\"1.0\"?>\n<collection xmlns=\"http://www.loc.gov/MARC21/slim\"></collection>")
       end
     end
   end

--- a/spec/models/marc_collection_document_callbacks_spec.rb
+++ b/spec/models/marc_collection_document_callbacks_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MarcCollectionDocumentCallbacks do
+  let(:io) { StringIO.new }
+  let(:document_callbacks) { described_class.new(io) }
+  describe '#start_element' do
+    it 'writes the opening tag with attributes' do
+      document_callbacks.start_element('datafield', [
+                                         ['tag', '245'],
+                                         ['ind1', '0'],
+                                         ['ind2', '0']
+                                       ])
+      expect(io.string).to eq('<datafield tag="245" ind1="0" ind2="0">')
+    end
+    it "writes the namespace if the <collection> doesn't already have it" do
+      document_callbacks.start_element('collection', [])
+      expect(io.string).to eq('<collection xmlns="http://www.loc.gov/MARC21/slim">')
+    end
+    it "just writes the opening tag if no attributes supplied" do
+      document_callbacks.start_element('record', [])
+      expect(io.string).to eq('<record>')
+    end
+  end
+
+  describe '#characters' do
+    it "escapes special XML characters" do
+      document_callbacks.characters('Vols. for 1972-<1982> called also vyp. 1-<8/2>.')
+      expect(io.string).to eq('Vols. for 1972-&lt;1982&gt; called also vyp. 1-&lt;8/2&gt;.')
+    end
+  end
+end


### PR DESCRIPTION
This patch replaces various occurences where huge MARC files are read into memory as Strings or StringIOs.  Instead, it uses:
* TempFiles on disk
* A SAX parser that allows us to read XML files into memory one element at a time, rather than all at once.
* Nokogiri in one case where we were using ReXML

Related to #695 

I tried this out on staging, and also the main branch, with 4 files:

| branch | peak memory consumption | memory consumption pattern | time |
| --- | --- | --- | --- |
| this one | 0.4 GB | steady during the whole run | 4 minutes 33 seconds |
| main | 1.2 GB | growing at a regular pace during the whole run | 4 minutes 7 seconds |

For what it's worth, there are 475 files that need to be processed in prod.
