### PR TITLE
Only initialize the S3 Connection once

### DIFF
--- a/app/models/alma_submit_collection/alma_submit_collection_job.rb
+++ b/app/models/alma_submit_collection/alma_submit_collection_job.rb
@@ -6,6 +6,8 @@ module AlmaSubmitCollection
     attr_reader :s3_partner
     def initialize
       super(category: 'AlmaSubmitCollection')
+      # We use the same S3 connection for the whole job,
+      # since each instance takes quite a bit of memory
       @s3_partner = AlmaSubmitCollection::PartnerS3.new
     end
 
@@ -13,7 +15,7 @@ module AlmaSubmitCollection
       file_list = AlmaRecapFileList.new
       records_processed = 0
       file_list.file_contents.each do |file|
-        processor = MarcFileProcessor.new(file:)
+        processor = MarcFileProcessor.new(file:, s3_partner:)
         processor.process
         records_processed += processor.records_processed
       end

--- a/app/models/alma_submit_collection/marc_file_processor.rb
+++ b/app/models/alma_submit_collection/marc_file_processor.rb
@@ -6,14 +6,14 @@ module AlmaSubmitCollection
   class MarcFileProcessor
     attr_reader :records_processed
 
-    def initialize(file:)
+    def initialize(file:, s3_partner:)
       @records_processed = 0
       Tempfile.create do |normalized_records|
         MarcCollection.new(file).write(normalized_records)
         @reader = MARC::XMLReader.new(normalized_records.path, parser: "nokogiri")
       end
-      @writer = MarcS3Writer.new(records_per_file: 10_000)
-      @constituent_writer = MarcS3Writer.new(records_per_file: 1_000, file_type: 'constituent')
+      @writer = MarcS3Writer.new(records_per_file: 10_000, s3_partner:)
+      @constituent_writer = MarcS3Writer.new(records_per_file: 1_000, file_type: 'constituent', s3_partner:)
     end
 
     def process

--- a/app/models/alma_submit_collection/marc_s3_writer.rb
+++ b/app/models/alma_submit_collection/marc_s3_writer.rb
@@ -6,11 +6,11 @@ module AlmaSubmitCollection
   class MarcS3Writer
     attr_reader :s3_partner, :client, :bucket
 
-    def initialize(records_per_file: 10_000, file_type: 'std')
+    def initialize(records_per_file: 10_000, file_type: 'std', s3_partner:)
       @records_in_file = 0
       @records_per_file = records_per_file
       @file_type = file_type
-      @s3_partner = AlmaSubmitCollection::PartnerS3.new
+      @s3_partner = s3_partner
       @client = @s3_partner.client
       @bucket = @s3_partner.bucket_name
     end

--- a/spec/models/alma_submit_collection/marc_file_processor_spec.rb
+++ b/spec/models/alma_submit_collection/marc_file_processor_spec.rb
@@ -4,14 +4,15 @@ require 'rails_helper'
 RSpec.describe AlmaSubmitCollection::MarcFileProcessor, type: :model do
   let(:filename) { 'host_record.xml' }
   let(:files_sent_to_s3) { [] }
+  let(:s3_partner) { instance_double(AlmaSubmitCollection::PartnerS3) }
   let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
-  let(:processor) { described_class.new(file: File.new(Pathname.new(file_fixture_path).join("alma", filename))) }
+  let(:processor) { described_class.new(file: File.new(Pathname.new(file_fixture_path).join("alma", filename)), s3_partner:) }
   let(:constituent_ids) { ["9933584373506421", "997007993506421", "997008003506421"] }
 
   before do
     stub_alma_bibs(ids: constituent_ids, status: 200, fixture: "constituent_records.xml", apikey: '1234')
-    allow_any_instance_of(AlmaSubmitCollection::PartnerS3).to receive(:s3_bucket).and_return('test-bucket')
-    allow_any_instance_of(AlmaSubmitCollection::PartnerS3).to receive(:s3_client_connection).and_return(s3_client)
+    allow(s3_partner).to receive(:bucket_name).and_return('test-bucket')
+    allow(s3_partner).to receive(:client).and_return(s3_client)
   end
   context "when the file has valid MARC records" do
     it 'processed all valid records in a file' do


### PR DESCRIPTION
Previously, we created 2 Aws::S3::Client objects for each file on the SFTP server: one for host/constitutent records, the other for bound-with records.  As part of its initialization, Aws::S3::Client slurps a 800 KB JSON file into memory, which it uses to determine the endpoint it wants to use.  800 KB isn't too bad, but if we add two copies to memory 4000 times, it leads to some serious memory pressure.

related to #695 