### PR TITLE
Use encode! rather than encode to modify string in place

### DIFF
--- a/app/models/marc_collection_document_callbacks.rb
+++ b/app/models/marc_collection_document_callbacks.rb
@@ -25,7 +25,7 @@ class MarcCollectionDocumentCallbacks < Nokogiri::XML::SAX::Document
 
   # Write any text that can be found in an open tag
   def characters(string)
-    @io.write string.encode(xml: :text)
+    @io.write string.encode!(xml: :text)
   end
 
   # Write the closing tag for an element

--- a/spec/models/marc_collection_document_callbacks_spec.rb
+++ b/spec/models/marc_collection_document_callbacks_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe MarcCollectionDocumentCallbacks do
 
   describe '#characters' do
     it "escapes special XML characters" do
-      document_callbacks.characters('Vols. for 1972-<1982> called also vyp. 1-<8/2>.')
+      # Nokogiri's SAX parser gives unfrozen strings to this callback, so we use the +
+      # in this test to make sure the string we pass is similarly unfrozen
+      document_callbacks.characters(+'Vols. for 1972-<1982> called also vyp. 1-<8/2>.')
       expect(io.string).to eq('Vols. for 1972-&lt;1982&gt; called also vyp. 1-&lt;8/2&gt;.')
     end
   end


### PR DESCRIPTION
This causes us to allocate slightly less memory.  These strings are not retained for very long, but since this method is called so many times, it does result in more work for the garbage collector.

part of #695 