### PR TITLE
Use Tempfiles, rather than StringIO, when decompressing a tarball

### DIFF
--- a/app/models/tarball.rb
+++ b/app/models/tarball.rb
@@ -5,7 +5,7 @@ require 'zlib'
 
 # take some .tar.gz IO (File, Net::SFTP::Operations::File, StringIO,
 # or similar) and make its uncompressed contents available as an
-# array of IO objects
+# array of Tempfile objects
 class Tarball
   def initialize(file)
     @file = file
@@ -14,7 +14,12 @@ class Tarball
   def contents
     @contents ||= untar.map do |entry|
       next unless entry.file?
-      StringIO.new entry.read
+      tempfile = Tempfile.new(binmode: true)
+      while (chunk = entry.read(10))
+        tempfile.write chunk
+      end
+      tempfile.rewind
+      tempfile
     end.compact
   end
 

--- a/spec/models/alma_submit_collection/alma_recap_file_list_spec.rb
+++ b/spec/models/alma_submit_collection/alma_recap_file_list_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AlmaSubmitCollection::AlmaRecapFileList, type: :model do
                     '<subfield code="b">Indian agriculture after liberalization /</subfield>'\
                     '<subfield code="c">edited by R. Ramakumar.</subfield></datafield>'
       decompressed_file_contents = alma_recap_file_list.download_and_decompress_file(alma_recap_filename)
-      expect(decompressed_file_contents.first.string).to include(title_field)
+      expect(decompressed_file_contents.first.read).to include(title_field)
     end
   end
   describe '#mark_files_as_processed' do


### PR DESCRIPTION
Part of #695 

This branch mysteriously allocates slightly more memory, but retains less memory overall. 