### PR TITLE
Allow less secure algorithms for some SFTP classes

### DIFF
--- a/app/models/gobi_sftp.rb
+++ b/app/models/gobi_sftp.rb
@@ -2,7 +2,8 @@
 class GobiSftp < Sftp
   def initialize(sftp_host: Rails.application.config.gobi_sftp.host,
                  sftp_username: Rails.application.config.gobi_sftp.username,
-                 sftp_password: Rails.application.config.gobi_sftp.password)
+                 sftp_password: Rails.application.config.gobi_sftp.password,
+                 allow_less_secure_algorithms: true)
     super
   end
 end

--- a/app/models/sftp.rb
+++ b/app/models/sftp.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 class Sftp
   attr_reader :sftp_host, :sftp_username
-  def initialize(sftp_host:, sftp_username:, sftp_password:)
+  def initialize(sftp_host:, sftp_username:, sftp_password:, allow_less_secure_algorithms: false)
     @sftp_host = sftp_host
     @sftp_username = sftp_username
     @sftp_password = sftp_password
+    @allow_less_secure_algorithms = allow_less_secure_algorithms
   end
 
   def start
     retries ||= 0
-    Net::SFTP.start(sftp_host, sftp_username, { password: @sftp_password }) do |sftp|
+    Net::SFTP.start(sftp_host, sftp_username,
+      { password: @sftp_password, append_all_supported_algorithms: @allow_less_secure_algorithms }) do |sftp|
       yield(sftp)
     end
   rescue Net::SSH::Disconnect => error

--- a/config/gobi_sftp.yml
+++ b/config/gobi_sftp.yml
@@ -2,14 +2,21 @@ default: &default
   host: <%= ENV['GOBI_SFTP_HOST'] || 'ftp.ybp.com' %>
   username: <%= ENV['GOBI_SFTP_USER'] || 'gobi' %>
   password: <%= ENV['GOBI_SFTP_PASSWORD'] || 'change_me' %>
-  isbn_export_file_path: '/prince/holdings'
+  output_sftp_base_dir: '/holdings'
+  working_directory: '/tmp/gobi'
+  gobi_account_code: <%= ENV['GOBI_ACCOUNT_CODE'] || '123499' %>
 
 development:
   <<: *default
+  working_directory: 'tmp/gobi'
 
 test:
   <<: *default
   host: 'localhost2'
+  working_directory: 'spec/fixtures/gobi'
+  gobi_account_code: '123499'
+  username: 'gobi'
+  password: 'pass'
 
 staging: &staging
   <<: *default

--- a/spec/models/alma_sftp_spec.rb
+++ b/spec/models/alma_sftp_spec.rb
@@ -2,31 +2,5 @@
 require "rails_helper"
 
 RSpec.describe AlmaSftp, type: :model do
-  include_context 'sftp'
-
-  let(:subject) { described_class.new }
-  let(:file_path) { "/alma/invoices/abc.xml" }
-
-  before do
-    allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
-  end
-  it 'downloads over sftp' do
-    subject.start { |sftp| sftp.download!(file_path) }
-    expect(sftp_session).to have_received(:download!).with(file_path).once
-  end
-
-  context 'with a spotty sftp connection' do
-    before do
-      allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
-      allow(Net::SFTP).to receive(:start).and_raise(Net::SSH::Disconnect)
-      allow(Rails.logger).to receive(:warn)
-      allow(Rails.logger).to receive(:error)
-    end
-    it 'tries the download 4 times, then stops' do
-      subject.start { |sftp| sftp.download!(file_path) }
-      expect(Net::SFTP).to have_received(:start).exactly(4).times
-      expect(Rails.logger).to have_received(:warn).exactly(3).times
-      expect(Rails.logger).to have_received(:error).once
-    end
-  end
+  it_behaves_like 'an sftp'
 end

--- a/spec/models/gobi_sftp_spec.rb
+++ b/spec/models/gobi_sftp_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe GobiSftp, type: :model do
+  it_behaves_like 'an sftp'
+  include_context 'sftp'
+  let(:file_path) { '/any/old/path' }
+
+  before do
+    allow(sftp_session).to receive(:download!)
+  end
+
+  it 'defaults to allowing less secure algorithms' do
+    described_class.new.start { |sftp| sftp.download!(file_path) }
+    expect(Net::SFTP).to have_received(:start).with("localhost2", "gobi", { password: "pass", append_all_supported_algorithms: true }).once
+  end
+end

--- a/spec/models/oclc_sftp_spec.rb
+++ b/spec/models/oclc_sftp_spec.rb
@@ -2,6 +2,7 @@
 require "rails_helper"
 
 RSpec.describe OclcSftp, type: :model do
+  it_behaves_like 'an sftp'
   let(:subject) { described_class.new }
 
   it 'has configuration' do
@@ -9,29 +10,8 @@ RSpec.describe OclcSftp, type: :model do
     expect(Rails.application.config.oclc_sftp.host).to eq('localhost2')
   end
 
-  it 'can be initialized without arguments' do
-    expect(described_class.new).to be
-  end
-
-  it 'can be initialized with arguments' do
-    expect(described_class.new(sftp_host: 'some_host', sftp_username: 'some_username', sftp_password: 'some_password')).to be
-  end
-
   it 'can access stfp info' do
     expect(subject.sftp_host).to eq('localhost2')
     expect(subject.sftp_username).to eq('fx_pul')
-  end
-
-  context 'with a mocked sftp connection' do
-    include_context 'sftp'
-
-    let(:file_path) { "spec/fixtures/oclc/metacoll.PUL.new.D20230706.T213019.MZallDLC.1.mrc" }
-    before do
-      allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'oclc', 'metacoll.PUL.new.D20230706.T213019.MZallDLC.1.mrc').read)
-    end
-    it 'downloads over sftp' do
-      subject.start { |sftp| sftp.download!(file_path) }
-      expect(sftp_session).to have_received(:download!).with(file_path).once
-    end
   end
 end

--- a/spec/models/sftp_spec.rb
+++ b/spec/models/sftp_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Sftp, type: :model do
+  include_context 'sftp'
+
+  let(:subject) { described_class.new(sftp_host: "example.com", sftp_username: "name", sftp_password: "pass") }
+  let(:file_path) { "/alma/invoices/abc.xml" }
+
+  before do
+    allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
+  end
+  it 'raises an error when instantiated without arguments' do
+    expect { described_class.new }.to raise_error(ArgumentError)
+  end
+  it 'downloads over sftp' do
+    subject.start { |sftp| sftp.download!(file_path) }
+    expect(sftp_session).to have_received(:download!).with(file_path).once
+  end
+
+  describe 'allowing all supported algorithms' do
+    it 'defaults to not appending all supported algorithms' do
+      subject.start { |sftp| sftp.download!(file_path) }
+      expect(Net::SFTP).to have_received(:start).with("example.com", "name", { password: "pass", append_all_supported_algorithms: false }).once
+    end
+
+    context 'when you want to allow less secure algorithms' do
+      let(:subject) { described_class.new(sftp_host: "example.com", sftp_username: "name", sftp_password: "pass", allow_less_secure_algorithms: true) }
+
+      it 'can append all supported algorithms' do
+        subject.start { |sftp| sftp.download!(file_path) }
+        expect(Net::SFTP).to have_received(:start).with("example.com", "name", { password: "pass", append_all_supported_algorithms: true }).once
+      end
+    end
+  end
+
+  context 'with a spotty sftp connection' do
+    before do
+      allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
+      allow(Net::SFTP).to receive(:start).and_raise(Net::SSH::Disconnect)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:error)
+    end
+    it 'tries the download 4 times, then stops' do
+      subject.start { |sftp| sftp.download!(file_path) }
+      expect(Net::SFTP).to have_received(:start).exactly(4).times
+      expect(Rails.logger).to have_received(:warn).exactly(3).times
+      expect(Rails.logger).to have_received(:error).once
+    end
+  end
+end

--- a/spec/support/sftp_shared_examples.rb
+++ b/spec/support/sftp_shared_examples.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an sftp' do
+  include_context 'sftp'
+  let(:sftp) { described_class.new }
+  let(:file_path) { '/any/old/path' }
+
+  before do
+    allow(sftp_session).to receive(:download!)
+  end
+
+  it 'can be instantiated without arguments' do
+    expect { described_class.new }.not_to raise_error
+  end
+
+  it 'can be instantiated with arguments' do
+    expect(described_class.new(sftp_host: 'some_host', sftp_username: 'some_username', sftp_password: 'some_password')).to be
+  end
+
+  it 'downloads over sftp' do
+    subject.start { |sftp| sftp.download!(file_path) }
+    expect(sftp_session).to have_received(:download!).with(file_path).once
+  end
+
+  context 'with a spotty sftp connection' do
+    before do
+      allow(sftp_session).to receive(:download!).with(file_path).and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
+      allow(Net::SFTP).to receive(:start).and_raise(Net::SSH::Disconnect)
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:error)
+    end
+    it 'tries the download 4 times, then stops' do
+      subject.start { |sftp| sftp.download!(file_path) }
+      expect(Net::SFTP).to have_received(:start).exactly(4).times
+      expect(Rails.logger).to have_received(:warn).exactly(3).times
+      expect(Rails.logger).to have_received(:error).once
+    end
+  end
+end


### PR DESCRIPTION
- The Gobi sftp server does not have modern algorithms available to authenticate with, so we have to append all supported algorithms, some of which are less secure
- Default to not appending the less secure algorithms
- Refactor SFTP specs to use shared examples when appropriate, add an SFTP spec for parent class
- Update Gobi sftp config, make sure they work for test and dev as well

Connected to #679