### PR TITLE
Add keyword configuration option to OCLC newly added

### DIFF
--- a/app/models/oclc/lc_call_slips/keyword_field.rb
+++ b/app/models/oclc/lc_call_slips/keyword_field.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+module Oclc
+  module LcCallSlips
+    # This class is responsible for searching a given
+    # Marc::DataField for the keywords that a selector
+    # is interested in.
+    class KeywordField
+      def initialize(field:, keywords:)
+        @field = field
+        @keywords = keywords
+      end
+
+      def match?
+        keyword_field? && field_contains_keywords?
+      end
+
+      private
+
+      attr_reader :field, :keywords
+
+      def keyword_field?
+        field.is_a?(MARC::DataField) && field.tag.match?(/^[12578]/)
+      end
+
+      def field_contains_keywords?
+        field.any? { |subfield| subfield_contains_keywords?(subfield) }
+      end
+
+      def subfield_contains_keywords?(subfield)
+        words_in_subfield = subfield.value.split(' ')
+        words_in_subfield.any? { |found_word| word_is_keyword? found_word }
+      end
+
+      def word_is_keyword?(word)
+        keywords.any? do |desired_keyword|
+          # Add ^ and $ to make sure that we match the whole world,
+          # then turn the * wildcard into .*
+          desired_keyword_as_regexp = Regexp.new('^' + desired_keyword.gsub('*', '.*') + '$', 'i')
+          word.match? desired_keyword_as_regexp
+        end
+      end
+    end
+  end
+end

--- a/app/models/oclc/lc_call_slips/record.rb
+++ b/app/models/oclc/lc_call_slips/record.rb
@@ -14,7 +14,7 @@ module Oclc
       end
 
       def relevant_to_selector?(selector:)
-        location_relevant_to_selector?(selector:) && (call_number_in_range_for_selector?(selector:) || subject_relevant_to_selector?(selector:))
+        location_relevant_to_selector?(selector:) && (call_number_in_range_for_selector?(selector:) || subject_relevant_to_selector?(selector:) || keywords_relevant_to_selector?(selector:))
       end
 
       def location_relevant_to_selector?(selector:)
@@ -39,6 +39,12 @@ module Oclc
         return true if selector.classes.include?(lc_class)
 
         false
+      end
+
+      def keywords_relevant_to_selector?(selector:)
+        keywords = selector.keywords
+        return false if keywords.blank?
+        record.fields.any? { |field| KeywordField.new(field:, keywords:).match? }
       end
 
       def subject_relevant_to_selector?(selector:)

--- a/app/models/oclc/lc_call_slips/selector.rb
+++ b/app/models/oclc/lc_call_slips/selector.rb
@@ -24,6 +24,10 @@ module Oclc
         call_number_ranges.pluck(:class).uniq
       end
 
+      def keywords
+        @keywords ||= selector_config[selector_key][:keywords]
+      end
+
       def subjects
         selector_config[selector_key][:subjects]
       end

--- a/spec/models/oclc/lc_call_slips/keyword_field_spec.rb
+++ b/spec/models/oclc/lc_call_slips/keyword_field_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Oclc::LcCallSlips::KeywordField do
+  shared_examples 'a match' do
+    it 'match? returns true' do
+      expect(described_class.new(field:, keywords:).match?).to eq(true)
+    end
+  end
+  shared_examples 'not a match' do
+    it 'match? returns false' do
+      expect(described_class.new(field:, keywords:).match?).to eq(false)
+    end
+  end
+  context 'when field is a control field' do
+    let(:field) { MARC::ControlField.new('001', 'SCSB-10482146') }
+    let(:keywords) { ['cantaloup*'] }
+    it_behaves_like 'not a match'
+  end
+
+  context 'when field is a 245' do
+    let(:field) do
+      MARC::DataField.new('245', '0', '0',
+            MARC::Subfield.new('a', 'Cantaloups'))
+    end
+    let(:keywords) { ['cantaloup*'] }
+    it_behaves_like 'a match'
+  end
+
+  context 'when field is a 246' do
+    let(:field) do
+      MARC::DataField.new('246', '0', '0',
+            MARC::Subfield.new('a', 'Cantaloupe culture'))
+    end
+    let(:keywords) { ['cantaloup*'] }
+    it_behaves_like 'a match'
+  end
+
+  context 'when field is a 260' do
+    let(:field) do
+      MARC::DataField.new('260', '0', '0',
+            MARC::Subfield.new('b', 'The Rocky Ford Cantaloupe Seed Breeders\' Association'))
+    end
+    let(:keywords) { ['cantaloup*'] }
+    it_behaves_like 'a match'
+    context 'when keyword includes multiple wildcards' do
+      let(:keywords) { ['*nt*loup*'] }
+      it_behaves_like 'a match'
+    end
+    context 'when the first matching keyword comes late in the array' do
+      let(:keywords) { ['sediment', 'metamorphosis', 'geolog*', 'igneous', 'rock*', 'sandstone'] }
+      it_behaves_like 'a match'
+    end
+  end
+
+  context 'when field is a 300' do
+    let(:field) do
+      MARC::DataField.new('300', '0', '0',
+            MARC::Subfield.new('a', '1 online resource (2 pages), digital, PDF file'))
+    end
+    let(:keywords) { ['online'] }
+    it_behaves_like 'not a match'
+  end
+end


### PR DESCRIPTION
Closes #678 

@maxkadel and I checked this by running the `lib_jobs:process_newly_cataloged_records` on main and on a branch with this commit and some testing keywords.  We downloaded the CSVs from mailcatcher and compared them.  The keywords did add a few records to the CSVs, and searching for the OCLC records in [firstsearch](https://libguides.princeton.edu/resource/4165) helped to confirm that those new records did in fact contain the keywords.