### PR TITLE
Refactor uploader for datasync exception and alma person feed

### DIFF
--- a/app/models/alma_people/alma_person_feed.rb
+++ b/app/models/alma_people/alma_person_feed.rb
@@ -53,10 +53,12 @@ module AlmaPeople
       Zip::File.open(filename + '.zip', Zip::File::CREATE) do |zipfile|
         zipfile.add(File.basename(filename), filename)
       end
-      alma_sftp = AlmaSftp.new
-      alma_sftp.start do |sftp|
-        sftp.upload!(filename + '.zip', File.join(Rails.application.config.alma_sftp.person_feed_path, "#{File.basename(filename)}.zip"))
-      end
+
+      working_file_names = ["#{File.basename(filename)}.zip"]
+      report_uploader = ReportUploader.new(working_file_names:,
+                                           working_file_directory: output_base_dir,
+                                           output_sftp_base_dir: Rails.application.config.alma_sftp.person_feed_path)
+      report_uploader.run
     end
 
     def convert_person_to_xml(xml:, person:)

--- a/app/models/oclc/data_sync_exception_job.rb
+++ b/app/models/oclc/data_sync_exception_job.rb
@@ -18,20 +18,6 @@ module Oclc
       @output_sftp_base_dir = output_sftp_base_dir
     end
 
-    def upload_files_to_alma_sftp(working_file_names:)
-      uploaded_file_paths = []
-      alma_sftp.start do |sftp|
-        working_file_names.each do |working_file_name|
-          source_file_path = File.join(working_file_directory, working_file_name)
-          destination_file_path = File.join(output_sftp_base_dir, working_file_name)
-          sftp.upload!(source_file_path, destination_file_path)
-          uploaded_file_paths << destination_file_path
-          Rails.logger.debug { "Uploaded source file: #{source_file_path} to sftp path: #{destination_file_path}" }
-        end
-      end
-      uploaded_file_paths
-    end
-
     private
 
     def handle(data_set:)


### PR DESCRIPTION
Connected to #743  

- the DataSyncExceptionJob wasn't actually using its `upload_files_to_alma_sftp` method, it was already using the ReportUploader.
- refactor the AlmaPersonFeed to use the ReportUploader

