### PR TITLE
[lc call slips] Add keywords to David Hollander's config

### DIFF
--- a/config/lc_call_slips.yml
+++ b/config/lc_call_slips.yml
@@ -253,6 +253,21 @@ default: &default
         - Rabbinical
         - Talmud
         include_us_uk_canada: true
+        keywords:
+        - Jewish
+        - Jews
+        - Jew
+        - Israel*
+        - Zionis*
+        - Hebrew
+        - Judaism
+        - Judaic
+        - Holocaust
+        - Antisemitism
+        - Geniza
+        - Rabbinic*
+        - Talmud
+        - Torah
     - painter:
         email: zp5928@princeton.edu
         classes:


### PR DESCRIPTION
closes #747 

I tested this on staging -- for this week, at least, the keywords don't add any additional titles that weren't already identified by call number or subject.