### PR TITLE
[lc call slips] ignore trailing punctuation when keyword matching

### DIFF
--- a/app/models/oclc/lc_call_slips/keyword_field.rb
+++ b/app/models/oclc/lc_call_slips/keyword_field.rb
@@ -36,8 +36,12 @@ module Oclc
           # Add ^ and $ to make sure that we match the whole world,
           # then turn the * wildcard into .*
           desired_keyword_as_regexp = Regexp.new('^' + desired_keyword.gsub('*', '.*') + '$', 'i')
-          word.match? desired_keyword_as_regexp
+          normalize(word).match? desired_keyword_as_regexp
         end
+      end
+
+      def normalize(word)
+        word.sub(/[[:punct:]]?$/, '')
       end
     end
   end

--- a/spec/models/oclc/lc_call_slips/keyword_field_spec.rb
+++ b/spec/models/oclc/lc_call_slips/keyword_field_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Oclc::LcCallSlips::KeywordField do
     it_behaves_like 'not a match'
   end
 
+  context 'when field is a 100' do
+    let(:field) do
+      MARC::DataField.new('100', '1', '',
+            MARC::Subfield.new('a', 'Westbrook, Catherine'))
+    end
+    let(:keywords) { ['Westbrook'] }
+    it_behaves_like 'a match'
+  end
+
   context 'when field is a 245' do
     let(:field) do
       MARC::DataField.new('245', '0', '0',


### PR DESCRIPTION
closes #754 