### PR TITLE
Refactor AlmaRenewList to use a tempfile rather than datastream

### DIFF
--- a/spec/models/alma_renew/alma_renew_list_spec.rb
+++ b/spec/models/alma_renew/alma_renew_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe AlmaRenew::AlmaRenewList, type: :model do
+RSpec.describe AlmaRenew::AlmaRenewList, type: :model, file_download: true do
   include_context 'sftp'
   subject(:alma_renew_list) { described_class.new }
 

--- a/spec/models/alma_renew/alma_renew_list_spec.rb
+++ b/spec/models/alma_renew/alma_renew_list_spec.rb
@@ -23,36 +23,51 @@ RSpec.describe AlmaRenew::AlmaRenewList, type: :model, file_download: true do
     allow(sftp_dir).to receive(:foreach).and_yield(sftp_entry1).and_yield(sftp_entry2)
     # only 1 should get downloaded
     pin_time_to_valid_invoice_list
-    allow(sftp_session).to receive(:download!).with("/alma/scsb_renewals/abc.csv").and_return(Rails.root.join('spec', 'fixtures', 'renew.csv').read)
+    allow(sftp_session).to receive(:download!).with("/alma/scsb_renewals/abc.csv", temp_file_one).and_return(temp_file_one)
     allow(sftp_session).to receive(:rename).with("/alma/scsb_renewals/abc.csv", "/alma/scsb_renewals/abc.csv.processed")
   end
 
-  around do |example|
-    temp_file_one.write(File.open(File.join('spec', 'fixtures', 'renew.csv')).read)
-    example.run
-  end
-
   describe "#renew_item_list" do
-    let(:expected_item_list) do
-      [
-        { "Barcode" => "32044061963013", "Patron Group" => "UGRD Undergraduate", "Primary Identifier" => "999999999", "Expiry Date" => "2023-10-31" },
-        { "Barcode" => "33433084897390", "Patron Group" => "SENR Senior Undergraduate", "Primary Identifier" => "999999999", "Expiry Date" => "2022-05-31" },
-        { "Barcode" => "CU53967402", "Patron Group" => "Graduate Student", "Primary Identifier" => "999999999", "Expiry Date" => "2022-10-31" },
-        { "Barcode" => "CU63769409", "Patron Group" => "P Faculty & Professional", "Primary Identifier" => "999999999", "Expiry Date" => "2023-10-31" },
-        { "Barcode" => "CU63769408", "Patron Group" => "REG Regular Staff", "Primary Identifier" => "999999999", "Expiry Date" => "2022-12-31" }
-      ]
-    end
-    it "creates a list of items" do
-      expect(alma_renew_list.renew_item_list).to be_instance_of(Array)
-      expect(alma_renew_list.renew_item_list.first).to be_instance_of(AlmaRenew::Item)
-      expect(alma_renew_list.renew_item_list.count).to eq 5
-      expect(alma_renew_list.renew_item_list.map(&:to_h)).to match_array(expected_item_list)
-      expect(sftp_session).to have_received(:download!).with("/alma/scsb_renewals/abc.csv")
+    context 'with a list with results' do
+      around do |example|
+        temp_file_one.write(File.open(File.join('spec', 'fixtures', 'renew.csv')).read)
+        temp_file_one.rewind
+        example.run
+      end
+      let(:expected_item_list) do
+        [
+          { "Barcode" => "32044061963013", "Patron Group" => "UGRD Undergraduate", "Primary Identifier" => "999999999", "Expiry Date" => "2023-10-31" },
+          { "Barcode" => "33433084897390", "Patron Group" => "SENR Senior Undergraduate", "Primary Identifier" => "999999999", "Expiry Date" => "2022-05-31" },
+          { "Barcode" => "CU53967402", "Patron Group" => "Graduate Student", "Primary Identifier" => "999999999", "Expiry Date" => "2022-10-31" },
+          { "Barcode" => "CU63769409", "Patron Group" => "P Faculty & Professional", "Primary Identifier" => "999999999", "Expiry Date" => "2023-10-31" },
+          { "Barcode" => "CU63769408", "Patron Group" => "REG Regular Staff", "Primary Identifier" => "999999999", "Expiry Date" => "2022-12-31" }
+        ]
+      end
+      it "creates a list of items" do
+        expect(alma_renew_list.renew_item_list).to be_instance_of(Array)
+        expect(alma_renew_list.renew_item_list.first).to be_instance_of(AlmaRenew::Item)
+        expect(alma_renew_list.renew_item_list.count).to eq 5
+        expect(alma_renew_list.renew_item_list.map(&:to_h)).to match_array(expected_item_list)
+        expect(sftp_session).to have_received(:download!).with("/alma/scsb_renewals/abc.csv", temp_file_one)
+      end
+
+      describe "#mark_files_as_processed" do
+        it "moves the files" do
+          alma_renew_list.mark_files_as_processed
+          expect(sftp_session).to have_received(:rename).with("/alma/scsb_renewals/abc.csv", "/alma/scsb_renewals/abc.csv.processed")
+        end
+      end
     end
 
     context "an empty list" do
       before do
-        allow(sftp_session).to receive(:download!).with("/alma/scsb_renewals/abc.csv").and_return(Rails.root.join('spec', 'fixtures', 'empty_renew.csv').read)
+        allow(sftp_session).to receive(:download!).with("/alma/scsb_renewals/abc.csv", temp_file_one).and_return(temp_file_one)
+      end
+
+      around do |example|
+        temp_file_one.write(File.open(Rails.root.join('spec', 'fixtures', 'empty_renew.csv')).read)
+        temp_file_one.rewind
+        example.run
       end
 
       it "parses the list " do
@@ -67,13 +82,6 @@ RSpec.describe AlmaRenew::AlmaRenewList, type: :model, file_download: true do
       it "throws an error" do
         expect { described_class.new }.to raise_error(CSVValidator::InvalidHeadersError)
       end
-    end
-  end
-
-  describe "#mark_files_as_processed" do
-    it "moves the files" do
-      alma_renew_list.mark_files_as_processed
-      expect(sftp_session).to have_received(:rename).with("/alma/scsb_renewals/abc.csv", "/alma/scsb_renewals/abc.csv.processed")
     end
   end
 end

--- a/spec/models/gobi/isbn_report_job_spec.rb
+++ b/spec/models/gobi/isbn_report_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Gobi::IsbnReportJob, type: :model do
+RSpec.describe Gobi::IsbnReportJob, type: :model, file_download: true do
   include_context 'sftp_gobi_isbn'
   let(:isbn_job) { described_class.new }
 

--- a/spec/models/oclc/data_sync_exception_job_spec.rb
+++ b/spec/models/oclc/data_sync_exception_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::DataSyncExceptionJob, type: :model do
+RSpec.describe Oclc::DataSyncExceptionJob, type: :model, file_download: true do
   subject(:data_sync_exception_job) { described_class.new }
   let(:working_file_name_1) { 'datasync_errors_20230713_103005835_1.mrc' }
   let(:working_file_name_2) { 'datasync_errors_20230713_103005835_2.mrc' }

--- a/spec/models/oclc/data_sync_processing_job_spec.rb
+++ b/spec/models/oclc/data_sync_processing_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::DataSyncProcessingJob, type: :model do
+RSpec.describe Oclc::DataSyncProcessingJob, type: :model, file_download: true do
   include_context 'sftp'
 
   subject(:processing_job) { described_class.new }

--- a/spec/models/oclc/lc_call_slips/all_relevant_job_spec.rb
+++ b/spec/models/oclc/lc_call_slips/all_relevant_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::AllRelevantJob, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::AllRelevantJob, type: :model, newly_cataloged: true, file_download: true do
   include_context 'sftp_newly_cataloged'
 
   subject(:newly_cataloged_job_all) { described_class.new }

--- a/spec/models/oclc/lc_call_slips/selector_job_spec.rb
+++ b/spec/models/oclc/lc_call_slips/selector_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::SelectorJob, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::SelectorJob, type: :model, newly_cataloged: true, file_download: true do
   include_context 'sftp_newly_cataloged'
 
   subject(:newly_cataloged_job) { described_class.new }

--- a/spec/models/report_downloader_spec.rb
+++ b/spec/models/report_downloader_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe ReportDownloader, type: :model do
+RSpec.describe ReportDownloader, type: :model, file_download: true do
   context "OCLC exception report downloader" do
     subject(:downloader) do
       described_class.new(file_pattern: 'BibExceptionReport.txt$', process_class: Oclc::DataSyncExceptionFile, input_sftp_base_dir: '/xfer/metacoll/reports/', recent: true)


### PR DESCRIPTION
- This is an incremental step toward using the ReportDownloader
- It may help with memory issues on the LibJobs boxes