### PR TITLE
I775 lc call slips config check

### DIFF
--- a/app/models/oclc/lc_call_slips/selector.rb
+++ b/app/models/oclc/lc_call_slips/selector.rb
@@ -4,8 +4,17 @@ module Oclc
   module LcCallSlips
     class Selector
       attr_reader :selector_config
+
       def initialize(selector_config:)
         @selector_config = selector_config
+      end
+
+      def valid?
+        (selector_config[selector_key].keys & required_config_keys) == required_config_keys
+      end
+
+      def required_config_keys
+        [:email, :classes]
       end
 
       def name

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,8 @@ module IlsApps
     # mode. Set to `true` to always raise errors, or `false` to always warn.
     config.flipflop.raise_strategy_errors = false
 
-    def config_for(*args)
-      build = super(*args)
+    def config_for(name, env: Rails.env)
+      build = super(name, env:)
       OpenStruct.new(build)
     end
 

--- a/docs/lc_call_slips/testing_on_staging.md
+++ b/docs/lc_call_slips/testing_on_staging.md
@@ -18,4 +18,4 @@ generates a CSV of possible records from OCLC,
 excluding ones that are typically filtered out like
 juvenile materials (based on the `generally_relevant?` method).  You can use this one to make
 sure that your CSV in mailcatcher includes all the
-expected rows.
+expected rows. It is generally put in the `/tmp/oclc/` directory on staging and production.

--- a/spec/models/oclc/lc_call_slips/all_relevant_job_spec.rb
+++ b/spec/models/oclc/lc_call_slips/all_relevant_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::AllRelevantJob, type: :model, newly_cataloged: true, file_download: true do
+RSpec.describe Oclc::LcCallSlips::AllRelevantJob, type: :model, lc_call_slips: true, file_download: true do
   include_context 'sftp_newly_cataloged'
 
   subject(:newly_cataloged_job_all) { described_class.new }

--- a/spec/models/oclc/lc_call_slips/config_spec.rb
+++ b/spec/models/oclc/lc_call_slips/config_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "configuration for lc call slips", lc_call_slips: true do
+  before do
+    string_inquirer = ActiveSupport::StringInquirer.new('production')
+    allow(Rails).to receive(:env).and_return(string_inquirer)
+  end
+
+  it 'has a configuration' do
+    config = Rails.application.config_for(:lc_call_slips, env: "production")
+    expect(config.selectors.map { |selector| selector.keys.first }).to include(:donatiello)
+  end
+end

--- a/spec/models/oclc/lc_call_slips/config_spec.rb
+++ b/spec/models/oclc/lc_call_slips/config_spec.rb
@@ -7,8 +7,16 @@ RSpec.describe "configuration for lc call slips", lc_call_slips: true do
     allow(Rails).to receive(:env).and_return(string_inquirer)
   end
 
+  let(:config) { Rails.application.config_for(:lc_call_slips, env: "production") }
+
   it 'has a configuration' do
-    config = Rails.application.config_for(:lc_call_slips, env: "production")
     expect(config.selectors.map { |selector| selector.keys.first }).to include(:donatiello)
+  end
+
+  it 'has only valid configurations in the config file' do
+    config.selectors.each do |selector_config|
+      selector = Oclc::LcCallSlips::Selector.new(selector_config:)
+      expect(selector.valid?).to be true
+    end
   end
 end

--- a/spec/models/oclc/lc_call_slips/record_spec.rb
+++ b/spec/models/oclc/lc_call_slips/record_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::Record, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::Record, type: :model, lc_call_slips: true do
   let(:marc_record) { marc_reader.first }
   let(:marc_reader) { MARC::Reader.new(oclc_fixture_file_path.to_s, external_encoding: 'UTF-8') }
   let(:selector_config) do

--- a/spec/models/oclc/lc_call_slips/selector_csv_spec.rb
+++ b/spec/models/oclc/lc_call_slips/selector_csv_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::SelectorCSV, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::SelectorCSV, type: :model, lc_call_slips: true do
   let(:subject) { described_class.new(selector_config:) }
   let(:new_csv_path_string) { 'spec/fixtures/oclc/2023-07-12-newly-cataloged-by-lc-bordelon.csv' }
   let(:new_csv_path_1) { Rails.root.join('spec', 'fixtures', 'oclc', '2023-07-12-newly-cataloged-by-lc-bordelon.csv') }

--- a/spec/models/oclc/lc_call_slips/selector_file_spec.rb
+++ b/spec/models/oclc/lc_call_slips/selector_file_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::SelectorFile, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::SelectorFile, type: :model, lc_call_slips: true do
   subject(:newly_cataloged_file) { described_class.new(temp_file:) }
   let(:oclc_fixture_file_path) { Rails.root.join('spec', 'fixtures', 'oclc', 'metacoll.PUL.new.D20230718.T213016.MZallDLC.1.mrc') }
   let(:temp_file) { Tempfile.new(encoding: 'ascii-8bit') }

--- a/spec/models/oclc/lc_call_slips/selector_job_spec.rb
+++ b/spec/models/oclc/lc_call_slips/selector_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::SelectorJob, type: :model, newly_cataloged: true, file_download: true do
+RSpec.describe Oclc::LcCallSlips::SelectorJob, type: :model, lc_call_slips: true, file_download: true do
   include_context 'sftp_newly_cataloged'
 
   subject(:newly_cataloged_job) { described_class.new }

--- a/spec/models/oclc/lc_call_slips/selector_spec.rb
+++ b/spec/models/oclc/lc_call_slips/selector_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Oclc::LcCallSlips::Selector, type: :model, newly_cataloged: true do
+RSpec.describe Oclc::LcCallSlips::Selector, type: :model, lc_call_slips: true do
   let(:first_selector_config) { Rails.application.config.lc_call_slips.selectors[0] }
   let(:second_selector_config) { Rails.application.config.lc_call_slips.selectors[1] }
 


### PR DESCRIPTION
- Refactors so we can test against production configuration when we want to, and test configuration by default
- Adds a validation method to Selectors model, currently only used in config test
  - This will allow us to be more confident that our production configuration doesn't break anything

Closes #775