### PR TITLE
Does not list working_file that never had data written to it

### DIFF
--- a/app/models/oclc/data_sync_exception_file.rb
+++ b/app/models/oclc/data_sync_exception_file.rb
@@ -43,6 +43,8 @@ module Oclc
       current_working_file_name = working_file_name
       rec_num = 0
       writer = nil
+      return nil if @error_accumulator.empty?
+
       @error_accumulator.each do |mms_id, errors|
         writer = marc_writer(rec_num:, writer:)
         record = marc_record(mms_id:, errors:)

--- a/app/models/report_downloader.rb
+++ b/app/models/report_downloader.rb
@@ -33,7 +33,7 @@ class ReportDownloader
         remote_filenames << remote_filename
       end
     end
-    working_file_names
+    working_file_names.compact
   end
 
   def date_in_range?(file_name:)

--- a/app/models/report_uploader.rb
+++ b/app/models/report_uploader.rb
@@ -23,7 +23,9 @@ class ReportUploader
 
   def upload_file(working_file_name, sftp_conn)
     source_file_path = File.join(working_file_directory, working_file_name)
+    Rails.logger.debug { "Source file path for sftp upload: #{source_file_path}" }
     destination_file_path = File.join(output_sftp_base_dir, working_file_name)
+    Rails.logger.debug { "Destination file path for sftp upload: #{destination_file_path}" }
     sftp_conn.upload!(source_file_path, destination_file_path)
     @uploaded_file_paths << destination_file_path
     Rails.logger.debug("Uploaded source file: #{source_file_path} to sftp path: #{destination_file_path}") # rubocop:disable Rails/EagerEvaluationLogMessage

--- a/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20240529.T011306010.1012676.pul.non-pcc_37850317700006421_new.mrc_247.BibExceptionReport.txt
+++ b/spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20240529.T011306010.1012676.pul.non-pcc_37850317700006421_new.mrc_247.BibExceptionReport.txt
@@ -1,0 +1,1 @@
+PUL_1012676_1716959586010::bib::9118225||||Data Error||marc_record_field_length_error

--- a/spec/models/oclc/data_sync_exception_file_spec.rb
+++ b/spec/models/oclc/data_sync_exception_file_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Oclc::DataSyncExceptionFile, type: :model do
       File.delete(new_file_for_alma_path_2) if File.exist?(new_file_for_alma_path_2)
     end
 
+    context 'with a file that only has a zero mms_id' do
+      let(:oclc_fixture_file_path) { 'spec/fixtures/oclc/PUL-PUL.1012676.IN.BIB.D20240529.T011306010.1012676.pul.non-pcc_37850317700006421_new.mrc_247.BibExceptionReport.txt' }
+
+      it 'does not save a new file' do
+        temp_file.rewind
+        expect(File.exist?(new_file_for_alma_path_1)).to be false
+        expect(File.exist?(new_file_for_alma_path_2)).to be false
+        expect(exception_file.process).to be nil
+        expect(File.exist?(new_file_for_alma_path_1)).to be false
+        expect(File.exist?(new_file_for_alma_path_2)).to be false
+      end
+    end
+
     it 'creates a file to be submitted to alma' do
       expect(File.exist?(new_file_for_alma_path_1)).to be false
       expect(File.exist?(new_file_for_alma_path_2)).to be false

--- a/spec/models/report_uploader_spec.rb
+++ b/spec/models/report_uploader_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ReportUploader, type: :model, file_upload: true do
           expect(Rails.logger).to have_received(:error).once.with("Error uploading source file: #{new_file_for_alma_path_1} to sftp path: #{alma_upload_path_1}")
         end
         it 'does not log success to the debug log' do
-          allow(Rails.logger).to receive(:debug).with("Uploaded source file: #{new_file_for_alma_path_2} to sftp path: #{alma_upload_path_2}")
+          allow(Rails.logger).to receive(:debug)
           subject.run
           expect(Rails.logger).to have_received(:debug).once.with("Uploaded source file: #{new_file_for_alma_path_2} to sftp path: #{alma_upload_path_2}")
           expect(Rails.logger).not_to have_received(:debug).with("Uploaded source file: #{new_file_for_alma_path_1} to sftp path: #{alma_upload_path_1}")


### PR DESCRIPTION
Does not list working_file that never had data written to it

- When there were no valid errors, no file was getting created, which meant we would try to upload a non-existent file.
- Add some more logging for future debugging

Closes https://github.com/pulibrary/lib_jobs/issues/643