### PR TITLE
[airtable staff directory] Add websiteUrl, bios, and expertise fields

### DIFF
--- a/app/models/air_table_staff/staff_directory_mapping.rb
+++ b/app/models/air_table_staff/staff_directory_mapping.rb
@@ -25,7 +25,10 @@ module AirTableStaff
         { airtable_field: :'pul:Unit', our_field: :unit },
         { airtable_field: :'pul:Team', our_field: :team },
         { airtable_field: :Title, our_field: :title },
-        { airtable_field: :'Area of Study', our_field: :areasOfStudy, transformer: ->(areas) { areas&.join('//') } }
+        { airtable_field: :'Area of Study', our_field: :areasOfStudy, transformer: ->(areas) { areas&.join('//') } },
+        { airtable_field: :'Website URL', our_field: :websiteUrl },
+        { airtable_field: :Bios, our_field: :bios },
+        { airtable_field: :Expertise, our_field: :expertise, transformer: ->(areas) { areas&.join('//') } }
       ]
     end
     # rubocop:enable Metrics/MethodLength

--- a/spec/fixtures/files/air_table/records_no_offset.json
+++ b/spec/fixtures/files/air_table/records_no_offset.json
@@ -15,7 +15,8 @@
                 "netid": "ab123",
                 "University Phone": "(123) 123-1234",
                 "pul:Preferred Name": "Phillip Librarian",
-                "Email": "ab123@princeton.edu"
+                "Email": "ab123@princeton.edu",
+                "Bios": "Hello\nMy research interests\nare\n\nfantastic!"
             }
          }
     ]

--- a/spec/models/air_table_staff/csv_builder_spec.rb
+++ b/spec/models/air_table_staff/csv_builder_spec.rb
@@ -11,10 +11,17 @@ RSpec.describe AirTableStaff::CSVBuilder do
      )
       .to_return(status: 200, body: File.read(file_fixture('air_table/records_no_offset.json')), headers: {})
   end
-  it 'creates a CSV object with data from the HTTP API' do
+  it 'creates a CSV string with data from the HTTP API' do
+    # The following CSV contains new lines within a single cell.
+    # Since the cell is in in double quotes, it will still be read
+    # as a single cell within a single row"
     expected = <<~END_CSV
-            puid,netid,phone,name,lastName,firstName,email,address,building,department,division,unit,team,title,areasOfStudy
-            123,ab123,(123) 123-1234,Phillip Librarian,Librarian,Phillip,ab123@princeton.edu,123 Stokes,Stokes,Stokes,,,,Library Collections Specialist V,Virtual Reality
+            puid,netid,phone,name,lastName,firstName,email,address,building,department,division,unit,team,title,areasOfStudy,websiteUrl,bios,expertise
+            123,ab123,(123) 123-1234,Phillip Librarian,Librarian,Phillip,ab123@princeton.edu,123 Stokes,Stokes,Stokes,,,,Library Collections Specialist V,Virtual Reality,,"Hello
+            My research interests
+            are
+
+            fantastic!",
         END_CSV
     directory = described_class.new
     expect(directory.to_csv).to eq(expected)

--- a/spec/models/air_table_staff/staff_directory_person_spec.rb
+++ b/spec/models/air_table_staff/staff_directory_person_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe AirTableStaff::StaffDirectoryPerson do
         'pul:Unit': 'Rare Books Cataloging Team',
         'pul:Team': 'IT, Discovery and Access Services',
         'Title': 'Library Software Engineer',
+        'Expertise': ['Discovery', 'Library Systems'],
+        'Bios': "Kevin has worked at Princeton since 2011. He has a M.S. in Library and Information Science from the University of Illinois at Urbana-Champaign." \
+          "\n\nKevin heads the Discovery and Access Services Team that supports the Library Catalog. \n",
+        'Website URL': 'https://github.com/kevinreiss',
         'Area of Study': ['Chemistry', 'African American Studies']
       }
       expected = [
@@ -36,7 +40,14 @@ RSpec.describe AirTableStaff::StaffDirectoryPerson do
         'Rare Books Cataloging Team', # unit
         'IT, Discovery and Access Services', # team
         'Library Software Engineer', # title
-        'Chemistry//African American Studies' # areasOfStudy
+        'Chemistry//African American Studies', # areasOfStudy
+        'https://github.com/kevinreiss', # websiteUrl
+        "Kevin has worked at Princeton since 2011. "\
+          "He has a M.S. in Library and Information Science "\
+          "from the University of Illinois at Urbana-Champaign."\
+          "\n\nKevin heads the Discovery and Access Services Team "\
+          "that supports the Library Catalog. \n", # bios
+        'Discovery//Library Systems' # expertise
       ]
 
       expect(described_class.new(json).to_a).to eq(expected)

--- a/spec/models/air_table_staff/staff_list_job_spec.rb
+++ b/spec/models/air_table_staff/staff_list_job_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe AirTableStaff::StaffListJob, type: :model do
       let(:first_row) do
         [
           '123', 'ab123', '(123) 123-1234', 'Phillip Librarian', 'Librarian', 'Phillip', 'ab123@princeton.edu',
-          '123 Stokes', 'Stokes', 'Stokes', nil, nil, nil, 'Library Collections Specialist V', 'Virtual Reality'
+          '123 Stokes', 'Stokes', 'Stokes', nil, nil, nil, 'Library Collections Specialist V', 'Virtual Reality',
+          nil, "Hello\nMy research interests\nare\n\nfantastic!", nil
         ]
       end
 


### PR DESCRIPTION
closes #799 

The CSV column headers for the new fields are `websiteUrl`, `bios`, and `expertise`, to keep consistent capitalization with the other column headers.