### PR TITLE
I806 use field ids for airtable

### DIFF
--- a/app/models/air_table_staff/json_value_extractor.rb
+++ b/app/models/air_table_staff/json_value_extractor.rb
@@ -10,7 +10,7 @@ module AirTableStaff
     end
 
     def extract
-      raw_value = json[field[:airtable_field]]
+      raw_value = json[field[:airtable_field_id]]
       transformer = field[:transformer]
       transformer ? transformer.call(raw_value) : raw_value
     end

--- a/app/models/air_table_staff/record_list.rb
+++ b/app/models/air_table_staff/record_list.rb
@@ -10,11 +10,12 @@ module AirTableStaff
     def base_url
       @base_url ||= begin
         base_id = 'appv7XA5FWS7DG9oe'
-        table_name = 'Synchronized%20Staff%20Directory%20View'
-        query_hash = { "view": "Grid view" }
+        table_id = 'tblM0iymGN5oqDUVm'
+        fields_to_use = StaffDirectoryMapping.new.fields.map { |field| field[:airtable_field_id].to_s }
+        query_hash = { "fields": fields_to_use, "returnFieldsByFieldId": "true" }
         URI::HTTPS.build(
           host: 'api.airtable.com',
-          path: "/v0/#{base_id}/#{table_name}",
+          path: "/v0/#{base_id}/#{table_id}",
           query: query_hash.to_query
         )
       end

--- a/app/models/air_table_staff/record_list.rb
+++ b/app/models/air_table_staff/record_list.rb
@@ -4,8 +4,20 @@ module AirTableStaff
   # of staff records taken from the Airtable API
   class RecordList
     def initialize
-      @base_url = "https://api.airtable.com/v0/appv7XA5FWS7DG9oe/Synchronized%20Staff%20Directory%20View?view=Grid%20view"
       @token = LibJobs.config[:airtable_token]
+    end
+
+    def base_url
+      @base_url ||= begin
+        base_id = 'appv7XA5FWS7DG9oe'
+        table_name = 'Synchronized%20Staff%20Directory%20View'
+        query_hash = { "view": "Grid view" }
+        URI::HTTPS.build(
+          host: 'api.airtable.com',
+          path: "/v0/#{base_id}/#{table_name}",
+          query: query_hash.to_query
+        )
+      end
     end
 
     # The library staff list is split into several pages.
@@ -29,7 +41,7 @@ module AirTableStaff
 
     private
 
-    attr_reader :base_url, :token
+    attr_reader :token
 
     def get_json(offset: nil)
       JSON.parse(response(offset:).body, symbolize_names: true)

--- a/app/models/air_table_staff/staff_directory_mapping.rb
+++ b/app/models/air_table_staff/staff_directory_mapping.rb
@@ -5,32 +5,34 @@ module AirTableStaff
   class StaffDirectoryMapping
     # A mapping of:
     #  - an airtable field (airtable_field)
+    #  - an airtable field id (airtable_field_id) - this should not change,
+    #      even if the column name changes on airtable
     #  - a column name we want for our csv (our_field)
     #  - an optional "transformer" lambda for converting the airtable values
     #    to the desired format for the csv
     # rubocop:disable Metrics/MethodLength
     def fields
       [
-        { airtable_field: :'University ID', our_field: :puid },
-        { airtable_field: :netid, our_field: :netid },
-        { airtable_field: :'University Phone', our_field: :phone },
-        { airtable_field: :'pul:Preferred Name', our_field: :name },
-        { airtable_field: :'Last Name', our_field: :lastName },
-        { airtable_field: :'First Name', our_field: :firstName },
-        { airtable_field: :Email, our_field: :email },
-        { airtable_field: :Address, our_field: :address },
-        { airtable_field: :'pul:Building', our_field: :building },
-        { airtable_field: :Division, our_field: :department },
-        { airtable_field: :'pul:Department', our_field: :division },
-        { airtable_field: :'pul:Unit', our_field: :unit },
-        { airtable_field: :'pul:Team', our_field: :team },
-        { airtable_field: :Title, our_field: :title },
-        { airtable_field: :'Area of Study', our_field: :areasOfStudy, transformer: ->(areas) { areas&.join('//') } },
-        { airtable_field: :'Website URL', our_field: :websiteUrl },
-        { airtable_field: :Bios, our_field: :bios },
-        { airtable_field: :Expertise, our_field: :expertise, transformer: ->(expertises) { expertises&.join('//') } },
-        { airtable_field: :'My Scheduler Link', our_field: :mySchedulerLink },
-        { airtable_field: :'Other Entities', our_field: :otherEntities, transformer: ->(entities) { entities&.join('//') } }
+        { airtable_field: :'University ID', airtable_field_id: :fldbquJ6Hn2eq1V2h, our_field: :puid },
+        { airtable_field: :netid, airtable_field_id: :fldgarsg3FzD8xpE4, our_field: :netid },
+        { airtable_field: :'University Phone', airtable_field_id: :fldqulY6ehd5aIbR1, our_field: :phone },
+        { airtable_field: :'pul:Preferred Name', airtable_field_id: :fldL7tm4jVvYksIwl, our_field: :name },
+        { airtable_field: :'Last Name', airtable_field_id: :fldcGj6p3JRzHzmZ8, our_field: :lastName },
+        { airtable_field: :'First Name', airtable_field_id: :fldL5IJdMuz8UCM81, our_field: :firstName },
+        { airtable_field: :Email, airtable_field_id: :fldbnDHHhDNlc2Lx8, our_field: :email },
+        { airtable_field: :Address, airtable_field_id: :fldKZxmtofNbXW4qS, our_field: :address },
+        { airtable_field: :'pul:Building', airtable_field_id: :fldz6yBenvTjdClXZ, our_field: :building },
+        { airtable_field: :Division, airtable_field_id: :fldxpCzkJmhEkVqZt, our_field: :department },
+        { airtable_field: :'pul:Department', airtable_field_id: :fld9NYFQePrPxbJJW, our_field: :division },
+        { airtable_field: :'pul:Unit', airtable_field_id: :fldusiuPpfSql6vSk, our_field: :unit },
+        { airtable_field: :'pul:Team', airtable_field_id: :fldGzh0SHZqlFk3aU, our_field: :team },
+        { airtable_field: :Title, airtable_field_id: :fldw0mjDdB48HstnB, our_field: :title },
+        { airtable_field: :'Area of Study', airtable_field_id: :fldCCTbVNKKBFXxrp, our_field: :areasOfStudy, transformer: ->(areas) { areas&.join('//') } },
+        { airtable_field: :'Website URL', airtable_field_id: :fld0MfgMlZd364YTR, our_field: :websiteUrl },
+        { airtable_field: :Bios, airtable_field_id: :fld4JloN0LxiFaTiw, our_field: :bios },
+        { airtable_field: :Expertise, airtable_field_id: :fldypTXdkQGpYgVDC, our_field: :expertise, transformer: ->(expertises) { expertises&.join('//') } },
+        { airtable_field: :'My Scheduler Link', airtable_field_id: :fldULoOUDSpoEpdAP, our_field: :mySchedulerLink },
+        { airtable_field: :'Other Entities', airtable_field_id: :fldXw9janMHvhBWvO, our_field: :otherEntities, transformer: ->(entities) { entities&.join('//') } }
       ]
     end
     # rubocop:enable Metrics/MethodLength

--- a/config/config.yml
+++ b/config/config.yml
@@ -36,6 +36,7 @@ test:
   <<: *defaults
   open_marc_records_location: "spec/fixtures/open_marc_records"
   alma_region: "https://api-na.hosted.exlibrisgroup.com"
+  airtable_token: "FAKE_AIRTABLE_TOKEN"
 
 production: &production
   <<: *defaults

--- a/spec/fixtures/files/air_table/records_no_offset.json
+++ b/spec/fixtures/files/air_table/records_no_offset.json
@@ -4,21 +4,21 @@
             "id": "recrhIUhcJw3lUlRE",
             "createdTime": "2024-01-30T22:16:16.000Z",
             "fields": {
-                "Address": "123 Stokes",
-                "Area of Study": ["Virtual Reality"],
-                "Division": "Stokes",
-                "pul:Building": "Stokes",
-                "Last Name": "Librarian",
-                "First Name": "Phillip",
-                "Title": "Library Collections Specialist V",
-                "University ID": "123",
-                "netid": "ab123",
-                "University Phone": "(123) 123-1234",
-                "pul:Preferred Name": "Phillip Librarian",
-                "Email": "ab123@princeton.edu",
-                "Bios": "Hello\nMy research interests\nare\n\nfantastic!",
-                "My Scheduler Link": "https://example.com",
-                "Other Entities": ["Industrial Relations", "James Madison Program"]
+                "fldKZxmtofNbXW4qS": "123 Stokes",
+                "fldCCTbVNKKBFXxrp": ["Virtual Reality"],
+                "fldxpCzkJmhEkVqZt": "Stokes",
+                "fldz6yBenvTjdClXZ": "Stokes",
+                "fldcGj6p3JRzHzmZ8": "Librarian",
+                "fldL5IJdMuz8UCM81": "Phillip",
+                "fldw0mjDdB48HstnB": "Library Collections Specialist V",
+                "fldbquJ6Hn2eq1V2h": "123",
+                "fldgarsg3FzD8xpE4": "ab123",
+                "fldqulY6ehd5aIbR1": "(123) 123-1234",
+                "fldL7tm4jVvYksIwl": "Phillip Librarian",
+                "fldbnDHHhDNlc2Lx8": "ab123@princeton.edu",
+                "fld4JloN0LxiFaTiw": "Hello\nMy research interests\nare\n\nfantastic!",
+                "fldULoOUDSpoEpdAP": "https://example.com",
+                "fldXw9janMHvhBWvO": ["Industrial Relations", "James Madison Program"]
             }
          }
     ]

--- a/spec/fixtures/files/air_table/records_with_offset.json
+++ b/spec/fixtures/files/air_table/records_with_offset.json
@@ -4,17 +4,17 @@
             "id": "recrhIUhcJw3lUlRE",
             "createdTime": "2025-01-30T22:16:16.000Z",
             "fields": {
-                "Address": "Firestone A floor",
-                "Area of Study": ["Cinema history", "Robots"],
-                "Division": "Special Collections",
-                "pul:Building": "Firestone",
-                "Last Name": "Carmant",
-                "First Name": "Drema",
-                "University ID": "456",
-                "netid": "zz99",
-                "University Phone": "(123) 555-5555",
-                "pul:Preferred Name": "Drema Carmant",
-                "Email": "zz99@princeton.edu"
+                "fldKZxmtofNbXW4qS": "Firestone A floor",
+                "fldCCTbVNKKBFXxrp": ["Cinema history", "Robots"],
+                "fldxpCzkJmhEkVqZt": "Special Collections",
+                "fldz6yBenvTjdClXZ": "Firestone",
+                "fldcGj6p3JRzHzmZ8": "Carmant",
+                "fldL5IJdMuz8UCM81": "Drema",
+                "fldbquJ6Hn2eq1V2h": "456",
+                "fldgarsg3FzD8xpE4": "zz99",
+                "fldqulY6ehd5aIbR1": "(123) 555-5555",
+                "fldL7tm4jVvYksIwl": "Drema Carmant",
+                "fldbnDHHhDNlc2Lx8": "zz99@princeton.edu"
             }
          }
     ], "offset": "naeQu2ul/Ash6eiQu"

--- a/spec/models/air_table_staff/csv_builder_spec.rb
+++ b/spec/models/air_table_staff/csv_builder_spec.rb
@@ -3,13 +3,7 @@ require 'rails_helper'
 
 RSpec.describe AirTableStaff::CSVBuilder do
   before do
-    stub_request(:get, "https://api.airtable.com/v0/appv7XA5FWS7DG9oe/Synchronized%20Staff%20Directory%20View?view=Grid%20view")
-      .with(
-       headers: {
-         'Authorization' => 'Bearer FAKE_AIRTABLE_TOKEN'
-       }
-     )
-      .to_return(status: 200, body: File.read(file_fixture('air_table/records_no_offset.json')), headers: {})
+    stub_airtable
   end
   it 'creates a CSV string with data from the HTTP API' do
     # The following CSV contains new lines within a single cell.

--- a/spec/models/air_table_staff/json_value_extractor_spec.rb
+++ b/spec/models/air_table_staff/json_value_extractor_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe AirTableStaff::JsonValueExtractor do
   context 'when there is no transformer lambda provided in field config' do
     it 'extracts the text verbatim' do
       json = { cat: 'tabby cat' }
-      field = { airtable_field: :cat }
+      field = { airtable_field_id: :cat }
       expect(described_class.new(json:, field:).extract).to eq('tabby cat')
     end
   end
   context 'when there is a transformer lambda provided in field config' do
     it 'extracts the text verbatim' do
       json = { cat: 'tabby cat' }
-      field = { airtable_field: :cat, transformer: ->(value) { "My favorite cat is #{value}" } }
+      field = { airtable_field_id: :cat, transformer: ->(value) { "My favorite cat is #{value}" } }
       expect(described_class.new(json:, field:).extract).to eq('My favorite cat is tabby cat')
     end
   end

--- a/spec/models/air_table_staff/staff_directory_mapping_spec.rb
+++ b/spec/models/air_table_staff/staff_directory_mapping_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AirTableStaff::StaffDirectoryMapping do
+  let(:directory_mapping) { described_class.new }
+  it 'has the expected form for fields' do
+    expect(directory_mapping.fields).to be_an_instance_of(Array)
+    directory_mapping.fields.each do |field|
+      expect(field.keys).to include(:airtable_field, :airtable_field_id, :our_field)
+    end
+  end
+end

--- a/spec/models/air_table_staff/staff_directory_person_spec.rb
+++ b/spec/models/air_table_staff/staff_directory_person_spec.rb
@@ -5,27 +5,27 @@ RSpec.describe AirTableStaff::StaffDirectoryPerson do
   describe '#to_a' do
     it 'uses the order from the mapping' do
       json = {
-        'pul:Preferred Name': 'Sage Archivist',
-        'University ID': '987654321',
-        'netid': 'ab1234',
-        'University Phone': '(609) 555-1234',
-        'Last Name': 'Archivist',
-        'First Name': 'Phoenix',
-        'Email': 'test@princeton.edu',
-        'Address': '123 Lewis Library',
-        'pul:Building': 'Stokes Library',
-        'Division': 'ReCAP',
-        'pul:Department': 'Cataloging and Metadata Services',
-        'pul:Unit': 'Rare Books Cataloging Team',
-        'pul:Team': 'IT, Discovery and Access Services',
-        'Title': 'Library Software Engineer',
-        'Expertise': ['Discovery', 'Library Systems'],
-        'Bios': "Kevin has worked at Princeton since 2011. He has a M.S. in Library and Information Science from the University of Illinois at Urbana-Champaign." \
+        'fldL7tm4jVvYksIwl': 'Sage Archivist',
+        'fldbquJ6Hn2eq1V2h': '987654321',
+        'fldgarsg3FzD8xpE4': 'ab1234',
+        'fldqulY6ehd5aIbR1': '(609) 555-1234',
+        'fldcGj6p3JRzHzmZ8': 'Archivist',
+        'fldL5IJdMuz8UCM81': 'Phoenix',
+        'fldbnDHHhDNlc2Lx8': 'test@princeton.edu',
+        'fldKZxmtofNbXW4qS': '123 Lewis Library',
+        'fldz6yBenvTjdClXZ': 'Stokes Library',
+        'fldxpCzkJmhEkVqZt': 'ReCAP',
+        'fld9NYFQePrPxbJJW': 'Cataloging and Metadata Services',
+        'fldusiuPpfSql6vSk': 'Rare Books Cataloging Team',
+        'fldGzh0SHZqlFk3aU': 'IT, Discovery and Access Services',
+        'fldw0mjDdB48HstnB': 'Library Software Engineer',
+        'fldypTXdkQGpYgVDC': ['Discovery', 'Library Systems'],
+        'fld4JloN0LxiFaTiw': "Kevin has worked at Princeton since 2011. He has a M.S. in Library and Information Science from the University of Illinois at Urbana-Champaign." \
           "\n\nKevin heads the Discovery and Access Services Team that supports the Library Catalog. \n",
-        'Website URL': 'https://github.com/kevinreiss',
-        'Area of Study': ['Chemistry', 'African American Studies'],
-        'My Scheduler Link': 'https://example.com',
-        'Other Entities': ['Industrial Relations', 'James Madison Program']
+        'fld0MfgMlZd364YTR': 'https://github.com/kevinreiss',
+        'fldCCTbVNKKBFXxrp': ['Chemistry', 'African American Studies'],
+        'fldULoOUDSpoEpdAP': 'https://example.com',
+        'fldXw9janMHvhBWvO': ['Industrial Relations', 'James Madison Program']
       }
       expected = [
         '987654321', # puid

--- a/spec/models/air_table_staff/staff_list_job_spec.rb
+++ b/spec/models/air_table_staff/staff_list_job_spec.rb
@@ -4,13 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AirTableStaff::StaffListJob, type: :model do
   before do
-    stub_request(:get, 'https://api.airtable.com/v0/appv7XA5FWS7DG9oe/Synchronized%20Staff%20Directory%20View?view=Grid%20view')
-      .with(
-     headers: {
-       'Authorization' => 'Bearer FAKE_AIRTABLE_TOKEN'
-     }
-   )
-      .to_return(status: 200, body: File.read(file_fixture('air_table/records_no_offset.json')), headers: {})
+    stub_airtable
   end
 
   context 'job is turned off' do

--- a/spec/support/stub_airtable.rb
+++ b/spec/support/stub_airtable.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module AirtableStubbing
+  BASE_AIRTABLE_URL = "https://api.airtable.com/v0/appv7XA5FWS7DG9oe/tblM0iymGN5oqDUVm?fields%5B%5D=fld0MfgMlZd364YTR&fields%5B%5D=fld4JloN0LxiFaTiw&fields%5B%5D=fld9NYFQePrPxbJJW&fields%5B%5D=fldCCTbVNKKBFXxrp&fields%5B%5D=fldGzh0SHZqlFk3aU&fields%5B%5D=fldKZxmtofNbXW4qS&fields%5B%5D=fldL5IJdMuz8UCM81&fields%5B%5D=fldL7tm4jVvYksIwl&fields%5B%5D=fldULoOUDSpoEpdAP&fields%5B%5D=fldXw9janMHvhBWvO&fields%5B%5D=fldbnDHHhDNlc2Lx8&fields%5B%5D=fldbquJ6Hn2eq1V2h&fields%5B%5D=fldcGj6p3JRzHzmZ8&fields%5B%5D=fldgarsg3FzD8xpE4&fields%5B%5D=fldqulY6ehd5aIbR1&fields%5B%5D=fldusiuPpfSql6vSk&fields%5B%5D=fldw0mjDdB48HstnB&fields%5B%5D=fldxpCzkJmhEkVqZt&fields%5B%5D=fldypTXdkQGpYgVDC&fields%5B%5D=fldz6yBenvTjdClXZ&returnFieldsByFieldId=true"
+  def stub_airtable(offset: false)
+    if offset
+      stub_airtable_with_offset
+    else
+      stub_airtable_without_offset
+    end
+  end
+
+  def stub_airtable_with_offset
+    with_offset_airtable_path = Pathname.new(file_fixture_path).join("air_table", 'records_with_offset.json')
+    stub_request(:get, BASE_AIRTABLE_URL)
+      .with(headers: {
+              'Authorization' => 'Bearer FAKE_AIRTABLE_TOKEN'
+            })
+      .to_return(status: 200, body: File.read(with_offset_airtable_path))
+
+    without_offset_airtable_path = Pathname.new(file_fixture_path).join("air_table", 'records_no_offset.json')
+    stub_request(:get, "#{BASE_AIRTABLE_URL}&offset=naeQu2ul/Ash6eiQu")
+      .with(headers: {
+              'Authorization' => 'Bearer FAKE_AIRTABLE_TOKEN'
+            })
+      .to_return(status: 200, body: File.read(without_offset_airtable_path))
+  end
+
+  def stub_airtable_without_offset
+    airtable_path = Pathname.new(file_fixture_path).join("air_table", 'records_no_offset.json')
+    stub_request(:get, BASE_AIRTABLE_URL)
+      .with(headers: {
+              'Authorization' => 'Bearer FAKE_AIRTABLE_TOKEN'
+            })
+      .to_return(status: 200, body: File.read(airtable_path))
+  end
+end
+
+RSpec.configure do |config|
+  config.include AirtableStubbing
+end


### PR DESCRIPTION
- Even if the field names change slightly, our API calls should not break
- Request specific fields, to make it less likely that we accidentally pull private data (there should not be any in that sheet, but an extra safeguard seems like a good idea)
- Add a test helper for the airtable request, since the url is so long, and so we don't have to change it across tests

Connected to https://github.com/pulibrary/lib_jobs/issues/806