### PR TITLE
Add class to update EADs on GitLab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'ed25519', '~> 1.3'
 gem 'faraday', '~> 2.7'
 gem "flipflop", git: "https://github.com/voormedia/flipflop.git", ref: "0d70d8e33483a9c0282ed8d6bca9c5ccd61e61e8"
 gem 'foreman'
+gem 'git'
 gem "health-monitor-rails", "12.4.0"
 gem 'honeybadger'
 gem 'icalendar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,11 @@ GEM
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     foreman (0.88.1)
+    git (2.3.3)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.1.2)
@@ -326,6 +331,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
+    process_executer (1.3.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -385,6 +391,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rbs (2.8.4)
+    rchardet (1.9.0)
     rdoc (6.10.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -580,6 +587,7 @@ DEPENDENCIES
   faraday (~> 2.7)
   flipflop!
   foreman
+  git
   health-monitor-rails (= 12.4.0)
   honeybadger
   icalendar

--- a/app/models/aspace_version_control/get_eads_job.rb
+++ b/app/models/aspace_version_control/get_eads_job.rb
@@ -37,7 +37,10 @@ module AspaceVersionControl
         # get eads from ids
         get_eads_from_ids(@dir, repo, @resource_ids)
         svn_errors = Svn.new.commit_eads_to_svn(path:)
+        GitLab.new.commit_eads_to_git(path:)
         @errors << svn_errors unless svn_errors.empty?
+      rescue Git::Error => error
+        Rails.logger.error("Error updating EADS using GitLab for repo #{repo} at path #{path}.\nError: #{error}")
       end
       data_set.data = report
       data_set.report_time = Time.zone.now

--- a/app/models/aspace_version_control/get_eads_job.rb
+++ b/app/models/aspace_version_control/get_eads_job.rb
@@ -97,6 +97,8 @@ module AspaceVersionControl
 
     def prepare_and_commit_to_git_lab(repo, path)
       git_lab_repo_path = repo_path(@local_git_lab_dir, path)
+      Rails.logger.info("Preparing commit to GitLab for #{git_lab_repo_path}")
+
       make_directories(git_lab_repo_path)
       get_eads_from_ids(git_lab_repo_path, repo, @resource_ids)
       GitLab.new.commit_eads_to_git(path:)

--- a/app/models/aspace_version_control/get_eads_job.rb
+++ b/app/models/aspace_version_control/get_eads_job.rb
@@ -6,25 +6,30 @@ require 'fileutils'
 module AspaceVersionControl
   class GetEadsJob < LibJob
     attr_reader :repos
-    def initialize(aspace_output_base_dir: Rails.application.config.aspace.aspace_files_output_path)
+    def initialize(aspace_output_base_dir_svn: Rails.application.config.aspace.aspace_files_output_path_svn)
       super(category: "EAD_export")
       @errors = []
-      @aspace_output_base_dir = aspace_output_base_dir
+      @aspace_output_base_dir_svn = aspace_output_base_dir_svn
       @repos = Rails.application.config.aspace.repos
     end
 
     def aspace_login
-      # configure access
-      @config = ArchivesSpace::Configuration.new({
-                                                   base_uri: ENV['ASPACE_URL'],
-                                                   base_repo: "",
-                                                   username: ENV['ASPACE_USER'],
-                                                   password: ENV['ASPACE_PASSWORD'],
-                                                   throttle: 0,
-                                                   verify_ssl: false
-                                                 })
-      # log in
-      @client = ArchivesSpace::Client.new(@config).login
+      aspace_client(aspace_config)
+    end
+
+    def aspace_config
+      @config ||= ArchivesSpace::Configuration.new({
+                                                     base_uri: ENV['ASPACE_URL'],
+                                                     base_repo: "",
+                                                     username: ENV['ASPACE_USER'],
+                                                     password: ENV['ASPACE_PASSWORD'],
+                                                     throttle: 0,
+                                                     verify_ssl: false
+                                                   })
+    end
+
+    def aspace_client(config)
+      @client ||= ArchivesSpace::Client.new(config).login
     end
 
     def handle(data_set:)
@@ -34,8 +39,9 @@ module AspaceVersionControl
         make_directories(path)
         # get resource ids
         get_resource_ids_for_repo(repo)
+        next unless @resource_ids
         # get eads from ids
-        get_eads_from_ids(@dir, repo, @resource_ids)
+        get_eads_from_ids(@svn_dir, repo, @resource_ids)
         svn_errors = Svn.new.commit_eads_to_svn(path:)
         GitLab.new.commit_eads_to_git(path:)
         @errors << svn_errors unless svn_errors.empty?
@@ -48,15 +54,24 @@ module AspaceVersionControl
     end
 
     def make_directories(path)
-      @dir = "#{@aspace_output_base_dir}/#{path}"
-      FileUtils.mkdir_p(@dir) unless Dir.exist?(@dir)
+      @svn_dir = "#{@aspace_output_base_dir_svn}/#{path}"
+      FileUtils.mkdir_p(@svn_dir) unless Dir.exist?(@svn_dir)
     end
 
     def get_resource_ids_for_repo(repo)
+      retries ||= 0
       @resource_ids = @client.get("/repositories/#{repo}/resources", {
                                     query: { all_ids: true }
                                   }).parsed
+
       @resource_ids
+    rescue Net::ReadTimeout => error
+      while (retries += 1) <= 3
+        Rails.logger.warn("Encountered #{error.class}: '#{error.message}' when connecting at #{Time.now.utc}, retrying in #{retries} second(s)...")
+        sleep(retries)
+        retry
+      end
+      Rails.logger.error("Encountered #{error.class}: '#{error.message}' at #{Time.now.utc}, unsuccessful in connecting after #{retries} retries")
     end
 
     def get_eads_from_ids(dir, repo, resource_ids)

--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AspaceVersionControl
-  # This class is responsible for committing EADs to SVN for version control
+  # This class is responsible for committing EADs to GitLab for version control
   class GitLab
     def commit_eads_to_git(path:)
       update

--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -46,7 +46,7 @@ module AspaceVersionControl
     end
 
     def self.git_repo_path
-      @git_repo_path ||= config.git_lab_local_repo_path
+      @git_repo_path ||= config.local_git_lab_dir
     end
 
     def self.config

--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module AspaceVersionControl
+  # This class is responsible for committing EADs to SVN for version control
+  class GitLab
+    def commit_eads_to_git(path:)
+      update
+      return unless changes?(path:)
+      add(path:)
+      commit
+      push
+    end
+
+    def repo
+      @repo ||=
+        begin
+          Git.clone(GitLab.git_uri, GitLab.git_repo_path)
+        rescue Git::Error
+          Git.open(GitLab.git_repo_path)
+        end
+    end
+
+    def update
+      repo.pull
+    end
+
+    def add(path:)
+      repo.add(path)
+    end
+
+    def commit
+      repo.commit('monthly snapshot of ASpace EADs')
+    end
+
+    delegate :push, to: :repo
+
+    def changes?(path:)
+      changed = repo.status.changed?(path) || repo.status.untracked?(path)
+      return changed if changed
+      Rails.logger.info("No changes present for #{path}")
+    end
+
+    def self.git_uri
+      @git_uri ||= "git@#{config.git_lab_host}:#{config.git_lab_source_path}.git"
+    end
+
+    def self.git_repo_path
+      @git_repo_path ||= config.git_lab_local_repo_path
+    end
+
+    def self.config
+      @config ||= Rails.application.config.aspace
+    end
+  end
+end

--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -35,7 +35,8 @@ module AspaceVersionControl
     delegate :push, to: :repo
 
     def changes?(path:)
-      changed = repo.status.changed?(path) || repo.status.untracked?(path)
+      repo_status = repo.status
+      changed = repo_status.changed.present? || repo_status.untracked.present?
       return true if changed
       Rails.logger.info("No changes present for #{path}")
       false

--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -36,8 +36,9 @@ module AspaceVersionControl
 
     def changes?(path:)
       changed = repo.status.changed?(path) || repo.status.untracked?(path)
-      return changed if changed
+      return true if changed
       Rails.logger.info("No changes present for #{path}")
+      false
     end
 
     def self.git_uri

--- a/app/models/aspace_version_control/svn.rb
+++ b/app/models/aspace_version_control/svn.rb
@@ -14,7 +14,7 @@ module AspaceVersionControl
 
     def initialize
       config = Rails.application.config.aspace
-      @aspace_output_base_dir = config.aspace_files_output_path
+      @aspace_output_base_dir = config.aspace_files_output_path_svn
       @svn_username = config.svn_username
       @svn_password = config.svn_password
       @errors = []

--- a/app/models/aspace_version_control/svn.rb
+++ b/app/models/aspace_version_control/svn.rb
@@ -3,7 +3,7 @@
 module AspaceVersionControl
   # This class is responsible for committing EADs to SVN for version control
   class Svn
-    attr_reader :aspace_output_base_dir, :svn_username, :svn_password, :errors
+    attr_reader :local_svn_dir, :svn_username, :svn_password, :errors
 
     def commit_eads_to_svn(path: nil)
       svn_update
@@ -14,7 +14,7 @@ module AspaceVersionControl
 
     def initialize
       config = Rails.application.config.aspace
-      @aspace_output_base_dir = config.aspace_files_output_path_svn
+      @local_svn_dir = config.local_svn_dir
       @svn_username = config.svn_username
       @svn_password = config.svn_password
       @errors = []
@@ -23,19 +23,19 @@ module AspaceVersionControl
     private
 
     def svn_update
-      capture_output = Open3.capture3("svn update #{aspace_output_base_dir}")
+      capture_output = Open3.capture3("svn update #{local_svn_dir}")
       failure_comment = "Update failed"
       log_svn(capture_output, failure_comment)
     end
 
     def svn_add
-      capture_output = Open3.capture3("svn add --force #{aspace_output_base_dir}")
+      capture_output = Open3.capture3("svn add --force #{local_svn_dir}")
       failure_comment = "SVN Add failed"
       log_svn(capture_output, failure_comment)
     end
 
     def svn_commit(path: nil)
-      command = "svn commit #{aspace_output_base_dir}/#{path} -m 'monthly snapshot of ASpace EADs' --username #{svn_username} --password #{svn_password}"
+      command = "svn commit #{local_svn_dir}/#{path} -m 'monthly snapshot of ASpace EADs' --username #{svn_username} --password #{svn_password}"
       capture_output = Open3.capture3(command)
       failure_comment = "Commit failed"
       log_svn(capture_output, failure_comment)

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -1,5 +1,5 @@
 default: &default
-  aspace_files_output_path: subversion_eads
+  aspace_files_output_path_svn: subversion_eads
   svn_username: <%= ENV["SVN_USERNAME"] || 'libjobs' %>
   svn_password: <%= ENV["SVN_PASSWORD"] %>
   svn_host: <%= ENV["SVN_HOST"] %>
@@ -27,7 +27,7 @@ development:
 
 test:
   <<: *default
-  aspace_files_output_path: tmp/subversion_eads
+  aspace_files_output_path_svn: tmp/subversion_eads
   svn_username: "test-username"
   svn_password: "test-password"
   svn_host: "pretend-svn-host1.princeton.edu"

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -37,10 +37,19 @@ test:
   git_lab_source_path: mk8066/test-project-for-cloning
   local_git_lab_dir: tmp/gitlab_eads
   git_lab_local_repo_path: tmp/gitlab_eads
+  repos: 
+    3: "mudd/publicpolicy"
+    6: "rarebooks"
+    11: "ga"
+    12: "ea"
 
 staging:
   <<: *default
   git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-staging-vm.lib.princeton.edu' %>
+  repos: 
+    3: "mudd/publicpolicy"
+    11: "ga"
+    12: "ea"
 
 production:
   <<: *default

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -3,8 +3,8 @@ default: &default
   svn_username: <%= ENV["SVN_USERNAME"] || 'libjobs' %>
   svn_password: <%= ENV["SVN_PASSWORD"] %>
   svn_host: <%= ENV["SVN_HOST"] %>
-  git_lab_host: 'gitlab.lib.princeton.edu'
-  git_lab_source_path: scua/libsvn
+  git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-prod-vm.lib.princeton.edu' %>
+  git_lab_source_path: scua/eads
   git_lab_local_repo_path: git_lab_eads
   repos: 
     3: "mudd/publicpolicy"
@@ -22,7 +22,7 @@ development:
   <<: *default
   repos: 
     12: "ea"
-  git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
+  git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-staging-vm.lib.princeton.edu' %>
   git_lab_local_repo_path: tmp/gitlab_eads
 
 test:
@@ -37,7 +37,7 @@ test:
 
 staging:
   <<: *default
-  git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
+  git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-staging-vm.lib.princeton.edu' %>
 
 production:
   <<: *default

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -3,6 +3,9 @@ default: &default
   svn_username: <%= ENV["SVN_USERNAME"] || 'libjobs' %>
   svn_password: <%= ENV["SVN_PASSWORD"] %>
   svn_host: <%= ENV["SVN_HOST"] %>
+  git_lab_host: 'gitlab.lib.princeton.edu'
+  git_lab_source_path: scua/libsvn
+  git_lab_local_repo_path: git_lab_eads
   repos: 
     3: "mudd/publicpolicy"
     4: "mudd/univarchives"
@@ -19,6 +22,8 @@ development:
   <<: *default
   repos: 
     12: "ea"
+  git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
+  git_lab_local_repo_path: tmp/gitlab_eads
 
 test:
   <<: *default
@@ -26,9 +31,13 @@ test:
   svn_username: "test-username"
   svn_password: "test-password"
   svn_host: "pretend-svn-host1.princeton.edu"
+  git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
+  git_lab_source_path: mk8066/test-project-for-cloning
+  git_lab_local_repo_path: tmp/gitlab_eads
 
 staging:
   <<: *default
+  git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
 
 production:
   <<: *default

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -47,9 +47,8 @@ staging:
   <<: *default
   git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-staging-vm.lib.princeton.edu' %>
   repos: 
-    3: "mudd/publicpolicy"
+    10: "selectors"
     11: "ga"
-    12: "ea"
 
 production:
   <<: *default

--- a/config/aspace.yml
+++ b/config/aspace.yml
@@ -1,10 +1,11 @@
 default: &default
-  aspace_files_output_path_svn: subversion_eads
+  local_svn_dir: subversion_eads
   svn_username: <%= ENV["SVN_USERNAME"] || 'libjobs' %>
   svn_password: <%= ENV["SVN_PASSWORD"] %>
   svn_host: <%= ENV["SVN_HOST"] %>
   git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-prod-vm.lib.princeton.edu' %>
   git_lab_source_path: scua/eads
+  local_git_lab_dir: git_lab_eads
   git_lab_local_repo_path: git_lab_eads
   repos: 
     3: "mudd/publicpolicy"
@@ -23,16 +24,18 @@ development:
   repos: 
     12: "ea"
   git_lab_host: <%= ENV["GIT_LAB_HOST"] || 'gitlab-staging-vm.lib.princeton.edu' %>
+  local_git_lab_dir: tmp/gitlab_eads
   git_lab_local_repo_path: tmp/gitlab_eads
 
 test:
   <<: *default
-  aspace_files_output_path_svn: tmp/subversion_eads
+  local_svn_dir: tmp/subversion_eads
   svn_username: "test-username"
   svn_password: "test-password"
   svn_host: "pretend-svn-host1.princeton.edu"
   git_lab_host: 'gitlab-staging-vm.lib.princeton.edu'
   git_lab_source_path: mk8066/test-project-for-cloning
+  local_git_lab_dir: tmp/gitlab_eads
   git_lab_local_repo_path: tmp/gitlab_eads
 
 staging:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,52 +24,6 @@
       "note": "File is accessed via index on a list of files in a known directory"
     },
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "06aeabbb88331cf204d0f19d0b288680447d9353c9bf4c439ba286a987f6fde6",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/models/aspace_version_control/svn.rb",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Open3.capture3(\"svn add --force #{aspace_output_base_dir}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AspaceVersionControl::Svn",
-        "method": "svn_add"
-      },
-      "user_input": "aspace_output_base_dir",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": "Variable comes from configuration, not user input"
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "0d635e61d0aa4296c90ea1ed94bfae8be7ae0b08de3e30ed0d12c1b3c1b1e55e",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/models/aspace_version_control/svn.rb",
-      "line": 39,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Open3.capture3(\"svn commit #{aspace_output_base_dir}/#{path} -m 'monthly snapshot of ASpace EADs' --username #{svn_username} --password #{svn_password}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AspaceVersionControl::Svn",
-        "method": "svn_commit"
-      },
-      "user_input": "aspace_output_base_dir",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": "Variable comes from configuration, not user input"
-    },
-    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "5c6e06cf13b6203f13666dfbe7cc0a0eb0f1e36b550488b1ec962ae34beadee0",
@@ -91,6 +45,29 @@
         22
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "67d0c64d0c69defc946b40e3423f33c5990cfd73fb401c8c17ff5862022c0846",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/aspace_version_control/svn.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(\"svn add --force #{local_svn_dir}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "AspaceVersionControl::Svn",
+        "method": "svn_add"
+      },
+      "user_input": "local_svn_dir",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "Variable comes from configuration, not user input"
     },
     {
       "warning_type": "File Access",
@@ -118,20 +95,43 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "a84853dfd8c1eaadd9dfc38c5f0b13479ba35909cc38fbf756f3c76012e56f7d",
+      "fingerprint": "9a74335fc57581e66a82f9f6ea61e1b2e98744a78bc5e29a57d7075cac0b0527",
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "app/models/aspace_version_control/svn.rb",
       "line": 26,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "Open3.capture3(\"svn update #{aspace_output_base_dir}\")",
+      "code": "Open3.capture3(\"svn update #{local_svn_dir}\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "AspaceVersionControl::Svn",
         "method": "svn_update"
       },
-      "user_input": "aspace_output_base_dir",
+      "user_input": "local_svn_dir",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "Variable comes from configuration, not user input"
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "a5af14c847e4e0e735c9c3514348bbd84fa87252e5ca15042f2b058bb704e48a",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/aspace_version_control/svn.rb",
+      "line": 39,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(\"svn commit #{local_svn_dir}/#{path} -m 'monthly snapshot of ASpace EADs' --username #{svn_username} --password #{svn_password}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "AspaceVersionControl::Svn",
+        "method": "svn_commit"
+      },
+      "user_input": "local_svn_dir",
       "confidence": "Medium",
       "cwe_id": [
         77

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,7 +53,7 @@ before "deploy:reverted", "deploy:assets:precompile"
 
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
-set :linked_dirs, %w[open_marc_records subversion_eads]
+set :linked_dirs, %w[open_marc_records subversion_eads git_lab_eads]
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/spec/models/aspace_version_control/get_eads_job_spec.rb
+++ b/spec/models/aspace_version_control/get_eads_job_spec.rb
@@ -65,13 +65,7 @@ RSpec.describe AspaceVersionControl::GetEadsJob do
     it "creates directories for all relevant ead repos" do
       described_class.new.run
       expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'mudd', 'publicpolicy'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'mudd', 'univarchives'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'mss'))
       expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'rarebooks'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'cotsen'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'lae'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'eng'))
-      expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'selectors'))
       expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'ga'))
       expect(File).to exist(Rails.root.join('tmp', 'subversion_eads', 'ea'))
     end
@@ -149,7 +143,7 @@ RSpec.describe AspaceVersionControl::GetEadsJob do
           expect(out.report).to include "Unable to process XML for record 6/1234, please check the source XML for errors"
 
           # Ensure the process continues after logging exception
-          expect(FileUtils.identical?(Rails.root.join('tmp', 'subversion_eads', 'selectors', 'MyEadID.EAD.xml'),
+          expect(FileUtils.identical?(Rails.root.join('tmp', 'subversion_eads', 'ea', 'MyEadID.EAD.xml'),
                                       file_fixture('ead_corrected.xml'))).to be true
         end
       end

--- a/spec/models/aspace_version_control/get_eads_job_spec.rb
+++ b/spec/models/aspace_version_control/get_eads_job_spec.rb
@@ -5,7 +5,17 @@ require_relative '../../../app/models/aspace_version_control/get_eads_job.rb'
 RSpec.describe AspaceVersionControl::GetEadsJob do
   let(:status) { double }
   let(:repos) { Rails.application.config.aspace.repos }
+  let(:git_lab_repo) { Git.init('tmp/gitlab_eads') }
+
   before do
+    # GitLab mocks
+    allow(Git).to receive(:clone).and_return(git_lab_repo)
+    allow(git_lab_repo).to receive(:pull).and_return("Already up to date.")
+    allow(git_lab_repo).to receive(:add).and_return("")
+    allow(git_lab_repo).to receive(:commit).and_return("[main b1b385c] monthly snapshot of ASpace EADs\n 1 file changed, 0 insertions(+), 0 deletions(-)\n create mode 100644 testing")
+    allow(git_lab_repo).to receive(:push).and_return(nil)
+    # end GitLab mocks
+    # Subversion (SVN) mocks
     allow(status).to receive(:success?).and_return(true)
     allow(Open3).to receive(:capture3).with("svn update tmp/subversion_eads").and_return(["Updating 'subversion_eads':\nAt revision 18345.\n", "", status])
     allow(Open3).to receive(:capture3).with("svn add --force tmp/subversion_eads").and_return(["", "", status])
@@ -15,6 +25,7 @@ RSpec.describe AspaceVersionControl::GetEadsJob do
         .with(commit_command)
         .and_return(["Sending        subversion_eads/ea/EA01.EAD.xml\nTransmitting file data .done\nCommitting transaction...\nCommitted revision 18347.\n", "", status])
     end
+    # end Subversion (SVN) mocks
   end
   describe "#run" do
     before do

--- a/spec/models/aspace_version_control/get_eads_job_spec.rb
+++ b/spec/models/aspace_version_control/get_eads_job_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe AspaceVersionControl::GetEadsJob do
         it "records the error and completes the job" do
           out = described_class.new
           out.handle(data_set: DataSet.new(category: "EAD_export"))
-          expect(out.report).to eq "Unable to process XML for record 6/1234, please check the source XML for errors"
+          expect(out.report).to include "Unable to process XML for record 6/1234, please check the source XML for errors"
 
-          # Ensure the process continutes after logging exception
+          # Ensure the process continues after logging exception
           expect(FileUtils.identical?(Rails.root.join('tmp', 'subversion_eads', 'selectors', 'MyEadID.EAD.xml'),
                                       file_fixture('ead_corrected.xml'))).to be true
         end

--- a/spec/models/aspace_version_control/git_lab_spec.rb
+++ b/spec/models/aspace_version_control/git_lab_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AspaceVersionControl::GitLab do
+  it 'can access configuration' do
+    expect(described_class.git_uri).to eq('git@gitlab-staging-vm.lib.princeton.edu:mk8066/test-project-for-cloning.git')
+    expect(described_class.git_repo_path).to eq('tmp/gitlab_eads')
+  end
+  context 'calling original methods' do
+    let(:repo) { Git.init('tmp/gitlab_eads') }
+
+    context 'without a repository already cloned' do
+      before do
+        FileUtils.rm_rf('tmp/gitlab_eads')
+      end
+      it 'can instantiate a repository' do
+        allow(Git).to receive(:clone).and_return(repo)
+        allow(Git).to receive(:open)
+        git_lab = described_class.new
+        expect(git_lab.repo).to be_an_instance_of(Git::Base)
+        git_lab.repo
+        expect(Git).to have_received(:clone)
+        expect(Git).not_to have_received(:open)
+      end
+    end
+    context 'with a previously cloned repository' do
+      before do
+        FileUtils.rm_rf('tmp/gitlab_eads')
+        repo
+      end
+
+      it 'can instantiate a repository' do
+        allow(Git).to receive(:clone).and_raise(Git::Error)
+        allow(Git).to receive(:open).and_return(repo)
+        git_lab = described_class.new
+        expect(git_lab.repo).to be_an_instance_of(Git::Base)
+        git_lab.repo
+        expect(Git).to have_received(:clone)
+        expect(Git).to have_received(:open)
+      end
+
+      it 'can update from the repository' do
+        allow(Git).to receive(:clone).and_return(repo)
+        allow(repo).to receive(:pull).and_return("Already up to date.")
+        git_lab = described_class.new
+        git_lab.update
+        expect(repo).to have_received(:pull)
+      end
+      context 'with no changes' do
+        before do
+          repo.reset_hard
+        end
+
+        it 'does not attempt to add, commit, or push' do
+          allow(Rails.logger).to receive(:info)
+          allow(Git).to receive(:clone).and_return(repo)
+          allow(repo).to receive(:pull).and_return("Already up to date.")
+          allow(repo).to receive(:add).and_call_original
+          allow(repo).to receive(:commit).and_call_original
+          allow(repo).to receive(:push).and_call_original
+          described_class.new.commit_eads_to_git(path: 'testing')
+          expect(repo).to have_received(:pull)
+          expect(repo).not_to have_received(:add)
+          expect(repo).not_to have_received(:commit)
+          expect(repo).not_to have_received(:push)
+          expect(Rails.logger).to have_received(:info)
+        end
+      end
+      context 'with changes' do
+        before do
+          FileUtils.touch('tmp/gitlab_eads/testing')
+        end
+        after do
+          repo.reset_hard
+        end
+        it 'can add changes to a commit' do
+          allow(Git).to receive(:clone).and_return(repo)
+          allow(repo).to receive(:add).and_return("")
+          git_lab = described_class.new
+          git_lab.add(path: 'testing')
+          expect(repo).to have_received(:add).with('testing')
+        end
+
+        context 'with changes pushed' do
+          after do
+            FileUtils.rm_rf('tmp/gitlab_eads/testing')
+            repo.add
+            repo.commit('removing changes for testing')
+            repo.push
+          end
+
+          it 'has a parallel API to svn' do
+            allow(Git).to receive(:clone).and_return(repo)
+            allow(repo).to receive(:pull).and_return("Already up to date.")
+            allow(repo).to receive(:add).and_return("")
+            allow(repo).to receive(:commit).and_return("[main b1b385c] monthly snapshot of ASpace EADs\n 1 file changed, 0 insertions(+), 0 deletions(-)\n create mode 100644 testing")
+            allow(repo).to receive(:push).and_return(nil)
+            described_class.new.commit_eads_to_git(path: 'testing')
+            expect(repo).to have_received(:add).with('testing')
+            expect(repo).to have_received(:commit).with('monthly snapshot of ASpace EADs')
+            expect(repo).to have_received(:push)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Right now, the code runs the updates to SVN and GitLab in parallel. We can remove the SVN code once we are confident the GitLab code is working consistently as expected.

Connected to #877