### PR TITLE
Address test failure

### DIFF
--- a/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
+++ b/spec/models/peoplesoft_voucher/voucher_feed_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PeoplesoftVoucher::VoucherFeed, type: :model do
 
   describe "#run" do
     it "generates an xml file" do
+      travel_to Time.zone.local(2024)
       allow(sftp_dir).to receive(:foreach).and_yield(sftp_entry1)
       # only 1 & 3 should get downloaded
       allow(sftp_session).to receive(:download!).with("/alma/invoices/abc.xml").and_return(Rails.root.join('spec', 'fixtures', 'invoice_export_202118300518.xml').read)
@@ -34,6 +35,7 @@ RSpec.describe PeoplesoftVoucher::VoucherFeed, type: :model do
       expect(confirm_email.subject).to eq("Alma to Peoplesoft Voucher Feed Results")
       expect(confirm_email.html_part.body.to_s).to include("No errors were found with the invoices")
       expect(confirm_email.html_part.body.to_s).not_to include("No invoices available to process")
+      travel_back
     end
 
     it "does not generates xml files if no invoices are present" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,4 +68,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
Now that we have reached April 2025, we get a test failure with the following:

```
2021-03-30,PO-9999,XXX,111222333,1319.05,USD,124.94,A020RVUO,Invalid invoice date: must be between four years old and one month into the future
```