### PR TITLE
Alma People Feed: Update structure to match new OIT format

### DIFF
--- a/app/models/alma_people/oit_person_feed.rb
+++ b/app/models/alma_people/oit_person_feed.rb
@@ -32,7 +32,7 @@ module AlmaPeople
         http.request(request)
       end
       if result.instance_of?(Net::HTTPOK)
-        JSON.parse(result.body)
+        JSON.parse(result.body)['records']
       else
         Rails.logger.error("Unable to get person data with parameters #{uri}.  Error: #{result.message}")
         {}

--- a/app/models/alma_people/oit_person_feed.rb
+++ b/app/models/alma_people/oit_person_feed.rb
@@ -32,7 +32,7 @@ module AlmaPeople
         http.request(request)
       end
       if result.instance_of?(Net::HTTPOK)
-        JSON.parse(result.body)['records']
+        JSON.parse(result.body)['records']['record']
       else
         Rails.logger.error("Unable to get person data with parameters #{uri}.  Error: #{result.message}")
         {}

--- a/spec/models/alma_people/oit_person_feed_spec.rb
+++ b/spec/models/alma_people/oit_person_feed_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
   subject(:feed) { described_class.new(base_url: 'https://example.com', path: '/person_feed', access_token: token) }
   let(:token) { instance_double("AccessToken") }
 
-  let(:body) { '{"records":[ ]}' }
+  let(:body) { '{"records": {"record": [ ]}}' }
 
   describe "get" do
     before do
@@ -30,7 +30,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
 
     context "with people in the response" do
       let(:body) do
-        "{\"records\":[{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
+        "{\"records\": \"record\": {[{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
         "    \"INSERT_UPDATE_DATETIME\": \"2020-12-03T08:21:02.000-05:00\",\n     \"PVSTATCATEGORY\": \"EM\",\n     \"ADDRESS_END_DATE\": \"2021-10-31\",\n"\
         "     \"PVPATRONGROUP\": \"P\",\n     \"DEPTID\": \"9999\",\n     \"DEPT_DESCR\": \"PRINCO\",\n     \"EMPLID\": \"999999999\",\n"\
         "     \"PRF_OR_PRI_FIRST_NAM\": \"Sally\",\n     \"PRF_OR_PRI_LAST_NAME\": \"Smith\",\n     \"PRF_OR_PRI_MIDDLE_NAME\": \"Doe\",\n"\
@@ -45,7 +45,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
         "     \"PERM_STATE\": \"FL\",\n     \"PERM_POSTAL\": \"34209\",\n     \"PERM_COUNTRY_DESCR\": \"United States\",\n     \"PERM_STATE_DESCR\": \"Florida\",\n"\
         "     \"PERM_PHONE\": \"123/456-7890\",\n     \"DORM_COUNTRY\": null,\n     \"DORM_ADDRESS1\": null,\n     \"DORM_ADDRESS2\": null,\n     \"DORM_ADDRESS3\": null,\n"\
         "     \"DORM_ADDRESS4\": null,\n     \"DORM_CITY\": null,\n     \"DORM_COUNTY\": null,\n     \"DORM_STATE\": null,\n     \"DORM_POSTAL\": null,\n"\
-        "     \"DORM_COUNTRY_DESCR\": null,\n     \"DORM_STATE_DESCR\": null,\n     \"EMAIL_ADDRESS_END_DATE\": \"2022-10-30T20:00:00.000-04:00\"\n   }]}"
+        "     \"DORM_COUNTRY_DESCR\": null,\n     \"DORM_STATE_DESCR\": null,\n     \"EMAIL_ADDRESS_END_DATE\": \"2022-10-30T20:00:00.000-04:00\"\n   }]}}"
       end
 
       it "gets json data from the api" do

--- a/spec/models/alma_people/oit_person_feed_spec.rb
+++ b/spec/models/alma_people/oit_person_feed_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
   subject(:feed) { described_class.new(base_url: 'https://example.com', path: '/person_feed', access_token: token) }
   let(:token) { instance_double("AccessToken") }
 
-  let(:body) { '[ ]' }
+  let(:body) { '{"records":[ ]}' }
 
   describe "get" do
     before do
@@ -30,7 +30,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
 
     context "with people in the response" do
       let(:body) do
-        "[{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
+        "{\"records\":[{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
         "    \"INSERT_UPDATE_DATETIME\": \"2020-12-03T08:21:02.000-05:00\",\n     \"PVSTATCATEGORY\": \"EM\",\n     \"ADDRESS_END_DATE\": \"2021-10-31\",\n"\
         "     \"PVPATRONGROUP\": \"P\",\n     \"DEPTID\": \"9999\",\n     \"DEPT_DESCR\": \"PRINCO\",\n     \"EMPLID\": \"999999999\",\n"\
         "     \"PRF_OR_PRI_FIRST_NAM\": \"Sally\",\n     \"PRF_OR_PRI_LAST_NAME\": \"Smith\",\n     \"PRF_OR_PRI_MIDDLE_NAME\": \"Doe\",\n"\
@@ -45,7 +45,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
         "     \"PERM_STATE\": \"FL\",\n     \"PERM_POSTAL\": \"34209\",\n     \"PERM_COUNTRY_DESCR\": \"United States\",\n     \"PERM_STATE_DESCR\": \"Florida\",\n"\
         "     \"PERM_PHONE\": \"123/456-7890\",\n     \"DORM_COUNTRY\": null,\n     \"DORM_ADDRESS1\": null,\n     \"DORM_ADDRESS2\": null,\n     \"DORM_ADDRESS3\": null,\n"\
         "     \"DORM_ADDRESS4\": null,\n     \"DORM_CITY\": null,\n     \"DORM_COUNTY\": null,\n     \"DORM_STATE\": null,\n     \"DORM_POSTAL\": null,\n"\
-        "     \"DORM_COUNTRY_DESCR\": null,\n     \"DORM_STATE_DESCR\": null,\n     \"EMAIL_ADDRESS_END_DATE\": \"2022-10-30T20:00:00.000-04:00\"\n   }]"
+        "     \"DORM_COUNTRY_DESCR\": null,\n     \"DORM_STATE_DESCR\": null,\n     \"EMAIL_ADDRESS_END_DATE\": \"2022-10-30T20:00:00.000-04:00\"\n   }]}"
       end
 
       it "gets json data from the api" do
@@ -73,7 +73,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body2) do
-        "[{ \"EMPLID\": \"99998888\"\n   }]"
+        "{\"records\":[{ \"EMPLID\": \"99998888\"\n   }]}"
       end
 
       it "gets an new token and then gets data from the api" do
@@ -102,7 +102,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body3) do
-        "[{ \"EMPLID\": \"11112222\"\n   }]"
+        "{\"records\":[{ \"EMPLID\": \"11112222\"\n   }]}"
       end
 
       it "gets an new token and then gets data from the api" do
@@ -131,7 +131,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body3) do
-        "[{ \"EMPLID\": \"55556666\"\n   }]"
+        "{\"records\":[{ \"EMPLID\": \"55556666\"\n   }]}"
       end
 
       it "gets an new token and then gets data from the api" do

--- a/spec/models/alma_people/oit_person_feed_spec.rb
+++ b/spec/models/alma_people/oit_person_feed_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
 
     context "with people in the response" do
       let(:body) do
-        "{\"records\": \"record\": {[{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
+        "{\"records\": {\"record\": [{  \"PATRON_EXPIRATION_DATE\": \"2022-10-31\",\n     \"PATRON_PURGE_DATE\": \"2021-10-31\",\n     \"ELIGIBLE_INELIGIBLE\": \"E\",\n"\
         "    \"INSERT_UPDATE_DATETIME\": \"2020-12-03T08:21:02.000-05:00\",\n     \"PVSTATCATEGORY\": \"EM\",\n     \"ADDRESS_END_DATE\": \"2021-10-31\",\n"\
         "     \"PVPATRONGROUP\": \"P\",\n     \"DEPTID\": \"9999\",\n     \"DEPT_DESCR\": \"PRINCO\",\n     \"EMPLID\": \"999999999\",\n"\
         "     \"PRF_OR_PRI_FIRST_NAM\": \"Sally\",\n     \"PRF_OR_PRI_LAST_NAME\": \"Smith\",\n     \"PRF_OR_PRI_MIDDLE_NAME\": \"Doe\",\n"\
@@ -73,7 +73,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body2) do
-        "{\"records\":[{ \"EMPLID\": \"99998888\"\n   }]}"
+        "{\"records\":{\"record\":[{ \"EMPLID\": \"99998888\"\n   }]}}"
       end
 
       it "gets an new token and then gets data from the api" do
@@ -102,7 +102,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body3) do
-        "{\"records\":[{ \"EMPLID\": \"11112222\"\n   }]}"
+        "{\"records\":{\"record\":[{ \"EMPLID\": \"11112222\"\n   }]}}"
       end
 
       it "gets an new token and then gets data from the api" do
@@ -131,7 +131,7 @@ RSpec.describe AlmaPeople::OitPersonFeed do
       end
 
       let(:body3) do
-        "{\"records\":[{ \"EMPLID\": \"55556666\"\n   }]}"
+        "{\"records\":{\"record\":[{ \"EMPLID\": \"55556666\"\n   }]}}"
       end
 
       it "gets an new token and then gets data from the api" do


### PR DESCRIPTION
When we type the following into `rails c` on lib-jobs-production:

```
data = AlmaPeople::OitPersonFeed.new.get_json(begin_date: '2025-06-11', end_date: '2025-06-12')
```

It is very slow, but eventually `data` is:

```
{'records'=>'record'=>[All the data is here in a single array]}
```

I believe our code is expecting `data` to be a single array, without `records` and `record`.

This PR is not ready yet, it only looks at `records`