### PR TITLE
Add a job to get family, person and corporate entities agents

### DIFF
--- a/app/models/aspace_version_control/get_agents_job.rb
+++ b/app/models/aspace_version_control/get_agents_job.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+require 'archivesspace/client'
+require 'nokogiri'
+
+module AspaceVersionControl
+  # rubocop:disable Metrics/ClassLength
+  class GetAgentsJob < LibJob
+    def initialize
+      super(category: "Agents_export")
+      @errors = []
+    end
+
+    def aspace_login
+      aspace_client(aspace_config)
+    end
+
+    def aspace_config
+      raise "Missing required environment variables: ASPACE_URL, ASPACE_USER, or ASPACE_PASSWORD" unless ENV['ASPACE_URL'] && ENV['ASPACE_USER'] && ENV['ASPACE_PASSWORD']
+
+      @config ||= ArchivesSpace::Configuration.new({
+                                                     base_uri: ENV['ASPACE_URL'],
+                                                     username: ENV['ASPACE_USER'],
+                                                     password: ENV['ASPACE_PASSWORD'],
+                                                     throttle: 0,
+                                                     verify_ssl: false
+                                                   })
+    end
+
+    def aspace_client(config)
+      @client ||= ArchivesSpace::Client.new(config).login
+    rescue => error
+      Rails.logger.error("Failed to connect to ArchivesSpace: #{error.message}")
+      @errors << "ArchivesSpace connection failed: #{error.message}"
+      raise error
+    end
+
+    def handle(data_set:)
+      aspace_login
+      # TODO:  agent job
+      data_set.data = report
+      data_set.report_time = Time.zone.now
+      data_set
+    end
+
+    def report
+      if @errors.empty?
+        "Agents successfully exported."
+      else
+        @errors.join(', ')
+      end
+    end
+
+    def list_family_agents
+      @family_agents ||= @client.get("agents/families", {
+                                       query: { all_ids: true }
+                                     }).parsed
+    end
+
+    def list_corporate_entities_agents
+      @corporate_entities_agents ||= @client.get('agents/corporate_entities', {
+                                                   query: { all_ids: true }
+                                                 }).parsed
+    end
+
+    def list_person_agents
+      @person_agents ||= @client.get('agents/people', {
+                                       query: { all_ids: true }
+                                     }).parsed
+    end
+
+    def get_archival_context_xml(id, agent_type)
+      # repository 1 is the global repository in aspace that has all the agents
+      xml_str_body = @client.get("/repositories/1/archival_contexts/#{agent_type}/#{id}.xml").body
+      doc = Nokogiri::XML(xml_str_body)
+
+      filename_base = generate_cpf_filename(doc, id, agent_type)
+
+      {
+        xml_content: doc.to_xml,
+        filename: "#{filename_base}.CPF.xml"
+      }
+    end
+
+    # Methods to use separately if we want to schedule them individually
+    # or run them ad hoc
+
+    def get_person_archival_context_xml(id)
+      get_archival_context_xml(id, 'people')
+    end
+
+    def get_family_archival_context_xml(id)
+      get_archival_context_xml(id, 'families')
+    end
+
+    def get_corporate_entity_archival_context_xml(id)
+      get_archival_context_xml(id, 'corporate_entities')
+    end
+
+    def write_cpf_to_file(dir, id, agent_type)
+      Rails.logger.info("Processing CPF for #{agent_type}/#{id}")
+
+      cpf_data = get_archival_context_xml(id, agent_type)
+      filename = "#{dir}/#{cpf_data[:filename]}"
+
+      File.open(filename, "w") do |file|
+        file << cpf_data[:xml_content]
+      end
+
+      Rails.logger.info("Wrote CPF XML to #{filename}")
+      cpf_data[:filename]
+    rescue => error
+      err = "Unable to process CPF for #{agent_type}/#{id}: #{error.message}"
+      log_stdout(err)
+      log_stderr(err)
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def process_all_cpf_files(agent_type, output_dir, chunk_size: 500, start_from: 0)
+      agent_ids = get_agent_ids_by_type(agent_type)
+      total_count = agent_ids.count
+
+      Rails.logger.info("Processing #{total_count} #{agent_type} agents for CPF files (starting from #{start_from})")
+      FileUtils.mkdir_p(output_dir)
+
+      checkpoint_file = "#{output_dir}/#{agent_type}_checkpoint.txt"
+      start_from = resolve_start_position(checkpoint_file, start_from)
+
+      config = {
+        output_dir: output_dir,
+        start_from: start_from,
+        total_count: total_count,
+        chunk_size: chunk_size,
+        checkpoint_file: checkpoint_file
+      }
+      processed_count = process_agent_batch(agent_ids, agent_type, config)
+
+      cleanup_checkpoint(checkpoint_file)
+      Rails.logger.info("Completed processing: #{processed_count} #{agent_type} agents successful out of #{total_count - start_from} attempted")
+      processed_count
+    end
+    # enable Metrics/MethodLength
+
+    # Methods for each agent type in case we want to run them separately
+    def process_all_person_cpf_files(output_dir, chunk_size: 500, start_from: 0)
+      process_all_cpf_files('people', output_dir, chunk_size: chunk_size, start_from: start_from)
+    end
+
+    def process_all_family_cpf_files(output_dir, chunk_size: 500, start_from: 0)
+      process_all_cpf_files('families', output_dir, chunk_size: chunk_size, start_from: start_from)
+    end
+
+    def process_all_corporate_entity_cpf_files(output_dir, chunk_size: 500, start_from: 0)
+      process_all_cpf_files('corporate_entities', output_dir, chunk_size: chunk_size, start_from: start_from)
+    end
+
+    private
+
+    def get_agent_ids_by_type(agent_type)
+      case agent_type
+      when 'people'
+        list_person_agents
+      when 'families'
+        list_family_agents
+      when 'corporate_entities'
+        list_corporate_entities_agents
+      else
+        raise "Unknown agent type: #{agent_type}"
+      end
+    end
+
+    def resolve_start_position(checkpoint_file, start_from)
+      if File.exist?(checkpoint_file) && start_from.zero?
+        checkpoint_position = File.read(checkpoint_file).to_i
+        Rails.logger.info("Resuming from checkpoint: #{checkpoint_position}")
+        checkpoint_position
+      else
+        start_from
+      end
+    end
+
+    def process_agent_batch(agent_ids, agent_type, config)
+      processed_count = 0
+      output_dir = config[:output_dir]
+      start_from = config[:start_from]
+      total_count = config[:total_count]
+      chunk_size = config[:chunk_size]
+      checkpoint_file = config[:checkpoint_file]
+
+      agent_ids.drop(start_from).each_with_index do |id, relative_index|
+        absolute_index = start_from + relative_index
+
+        processed_count += 1 if process_single_agent(id, agent_type, output_dir, absolute_index)
+
+        handle_progress_and_checkpoints(absolute_index, total_count, agent_type, chunk_size, checkpoint_file)
+      end
+
+      processed_count
+    end
+
+    def process_single_agent(id, agent_type, output_dir, absolute_index)
+      write_cpf_to_file(output_dir, id, agent_type)
+      true
+    rescue => error
+      Rails.logger.error("Failed to process #{agent_type} agent #{id} at index #{absolute_index}: #{error.message}")
+      @errors << "#{agent_type} agent #{id}: #{error.message}"
+      false
+    end
+
+    def handle_progress_and_checkpoints(absolute_index, total_count, agent_type, chunk_size, checkpoint_file)
+      Rails.logger.info("Processed #{absolute_index + 1}/#{total_count} #{agent_type} agents") if ((absolute_index + 1) % 100).zero?
+
+      # Save checkpoint every chunk_size records
+      if ((absolute_index + 1) % chunk_size).zero?
+        File.write(checkpoint_file, absolute_index + 1)
+        Rails.logger.info("Checkpoint saved at #{absolute_index + 1}")
+        sleep(2)
+      elsif ((absolute_index + 1) % 20).zero?
+        sleep(0.05) # don't overwhelm the API with requests
+      end
+    end
+
+    def cleanup_checkpoint(checkpoint_file)
+      File.delete(checkpoint_file) if File.exist?(checkpoint_file)
+    end
+
+    def generate_cpf_filename(doc, id, agent_type)
+      namespace = { 'eac' => 'urn:isbn:1-931666-33-4' }
+
+      surname = doc.at_xpath('//eac:nameEntry/eac:part[@localType="surname"]', namespace)&.text
+      forename = doc.at_xpath('//eac:nameEntry/eac:part[@localType="forename"]', namespace)&.text
+
+      # Build name parts if they exist
+      name_parts = []
+      name_parts << surname.gsub(/\s+/, '').upcase if surname
+      name_parts << forename.gsub(/\s+/, '').upcase if forename
+
+      # Concatenate name parts, agent_type, and agent_id
+      filename_parts = []
+      filename_parts << name_parts.join('_') if name_parts.any?
+      filename_parts << agent_type
+      filename_parts << id.to_s
+
+      filename_parts.join('_')
+    end
+
+    def log_stderr(stderr_str)
+      @errors << stderr_str unless stderr_str.empty?
+    end
+
+    def log_stdout(stdout_str)
+      Rails.logger.info(stdout_str) unless stdout_str.empty?
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/spec/models/aspace_version_control/get_agents_job_spec.rb
+++ b/spec/models/aspace_version_control/get_agents_job_spec.rb
@@ -1,0 +1,395 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require_relative '../../../app/models/aspace_version_control/get_agents_job.rb'
+
+RSpec.describe AspaceVersionControl::GetAgentsJob do
+  let(:agents_job) { described_class.new }
+  let(:mock_client) { double('ArchivesSpace::Client') }
+  let(:mock_config) { double('ArchivesSpace::Configuration') }
+
+  # Sample CPF XML response
+  let(:cpf_xml_body) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <eac-cpf xmlns="urn:isbn:1-931666-33-4">
+        <control>
+          <recordId>SMITHHENRYBRADFORD</recordId>
+          <maintenanceStatus>revised</maintenanceStatus>
+        </control>
+        <cpfDescription>
+          <identity>
+            <entityId>SMITHHENRYBRADFORD</entityId>
+            <entityType>person</entityType>
+            <nameEntry>
+              <part localType="surname">Smith</part>
+              <part localType="forename">Henry Bradford</part>
+              <authorizedForm>local</authorizedForm>
+            </nameEntry>
+          </identity>
+        </cpfDescription>
+      </eac-cpf>
+    XML
+  end
+
+  let(:cpf_response) do
+    double('ArchivesSpace::Response', body: cpf_xml_body)
+  end
+
+  let(:agent_ids_response) do
+    double('ArchivesSpace::Response', parsed: [13, 14, 15])
+  end
+
+  before do
+    # Environment variable mocks
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("ASPACE_URL").and_return("https://aspace-staging.princeton.edu/staff/api")
+    allow(ENV).to receive(:[]).with("ASPACE_USER").and_return("testuser")
+    allow(ENV).to receive(:[]).with("ASPACE_PASSWORD").and_return("testpassword")
+
+    # ArchivesSpace client mocks
+    allow(ArchivesSpace::Configuration).to receive(:new).and_return(mock_config)
+    allow(ArchivesSpace::Client).to receive(:new).and_return(mock_client)
+    allow(mock_client).to receive(:login).and_return(mock_client)
+  end
+
+  describe "#initialize" do
+    it "sets up the job with correct category" do
+      expect(agents_job.instance_variable_get(:@errors)).to eq([])
+    end
+  end
+
+  describe "#aspace_config" do
+    it "creates a configuration with environment variables" do
+      expect(ArchivesSpace::Configuration).to receive(:new).with({
+                                                                   base_uri: "https://aspace-staging.princeton.edu/staff/api",
+                                                                   username: "testuser",
+                                                                   password: "testpassword",
+                                                                   throttle: 0,
+                                                                   verify_ssl: false
+                                                                 })
+      agents_job.aspace_config
+    end
+
+    context "when environment variables are missing" do
+      before do
+        allow(ENV).to receive(:[]).with("ASPACE_URL").and_return(nil)
+      end
+
+      it "raises an error" do
+        expect { agents_job.aspace_config }.to raise_error("Missing required environment variables: ASPACE_URL, ASPACE_USER, or ASPACE_PASSWORD")
+      end
+    end
+  end
+
+  describe "#aspace_login" do
+    it "establishes connection and returns client" do
+      expect(agents_job.aspace_login).to eq(mock_client)
+    end
+
+    context "when connection fails" do
+      before do
+        allow(mock_client).to receive(:login).and_raise(StandardError.new("Connection failed"))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "logs error and re-raises" do
+        expect { agents_job.aspace_login }.to raise_error("Connection failed")
+        expect(Rails.logger).to have_received(:error).with("Failed to connect to ArchivesSpace: Connection failed")
+      end
+    end
+  end
+
+  describe "agent listing methods" do
+    before do
+      agents_job.instance_variable_set(:@client, mock_client)
+    end
+
+    describe "#list_family_agents" do
+      before do
+        allow(mock_client).to receive(:get).with("agents/families", { query: { all_ids: true } }).and_return(agent_ids_response)
+      end
+
+      it "returns parsed list of family agent IDs" do
+        expect(agents_job.list_family_agents).to eq([13, 14, 15])
+      end
+    end
+
+    describe "#list_corporate_entities_agents" do
+      before do
+        allow(mock_client).to receive(:get).with("agents/corporate_entities", { query: { all_ids: true } }).and_return(agent_ids_response)
+      end
+
+      it "returns parsed list of corporate entity agent IDs" do
+        expect(agents_job.list_corporate_entities_agents).to eq([13, 14, 15])
+      end
+    end
+
+    describe "#list_person_agents" do
+      before do
+        allow(mock_client).to receive(:get).with("agents/people", { query: { all_ids: true } }).and_return(agent_ids_response)
+      end
+
+      it "returns parsed list of person agent IDs" do
+        expect(agents_job.list_person_agents).to eq([13, 14, 15])
+      end
+    end
+  end
+
+  describe "#get_archival_context_xml" do
+    before do
+      agents_job.instance_variable_set(:@client, mock_client)
+      allow(mock_client).to receive(:get).with("/repositories/1/archival_contexts/people/13.xml").and_return(cpf_response)
+    end
+
+    it "returns XML content and filename for person agent" do
+      result = agents_job.get_archival_context_xml(13, 'people')
+
+      expect(result[:xml_content]).to include('<?xml version="1.0" encoding="UTF-8"?>')
+      expect(result[:xml_content]).to include('<part localType="surname">Smith</part>')
+      expect(result[:xml_content]).to include('<part localType="forename">Henry Bradford</part>')
+      expect(result[:xml_content]).to include('<authorizedForm>local</authorizedForm>')
+      expect(result[:filename]).to eq('SMITH_HENRYBRADFORD_people_13.CPF.xml')
+    end
+
+    it "makes correct API call for different agent types" do
+      expect(mock_client).to receive(:get).with("/repositories/1/archival_contexts/families/13.xml").and_return(cpf_response)
+      agents_job.get_archival_context_xml(13, 'families')
+    end
+  end
+
+  describe "convenience methods" do
+    before do
+      agents_job.instance_variable_set(:@client, mock_client)
+      allow(mock_client).to receive(:get).and_return(cpf_response)
+    end
+
+    describe "#get_person_archival_context_xml" do
+      it "calls generic method with people type" do
+        expect(agents_job).to receive(:get_archival_context_xml).with(13, 'people')
+        agents_job.get_person_archival_context_xml(13)
+      end
+    end
+
+    describe "#get_family_archival_context_xml" do
+      it "calls generic method with families type" do
+        expect(agents_job).to receive(:get_archival_context_xml).with(13, 'families')
+        agents_job.get_family_archival_context_xml(13)
+      end
+    end
+
+    describe "#get_corporate_entity_archival_context_xml" do
+      it "calls generic method with corporate_entities type" do
+        expect(agents_job).to receive(:get_archival_context_xml).with(13, 'corporate_entities')
+        agents_job.get_corporate_entity_archival_context_xml(13)
+      end
+    end
+  end
+
+  describe "#write_cpf_to_file" do
+    let(:temp_dir) { 'tmp/test_agents' }
+
+    before do
+      FileUtils.mkdir_p(temp_dir)
+      agents_job.instance_variable_set(:@client, mock_client)
+      allow(mock_client).to receive(:get).and_return(cpf_response)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    after do
+      FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir)
+    end
+
+    it "writes CPF XML to file with correct filename" do
+      filename = agents_job.write_cpf_to_file(temp_dir, 13, 'people')
+
+      expect(File.exist?("#{temp_dir}/SMITH_HENRYBRADFORD_people_13.CPF.xml")).to be true
+      expect(filename).to eq('SMITH_HENRYBRADFORD_people_13.CPF.xml')
+
+      file_content = File.read("#{temp_dir}/SMITH_HENRYBRADFORD_people_13.CPF.xml")
+      expect(file_content).to include('<entityId>SMITHHENRYBRADFORD</entityId>')
+    end
+
+    it "logs processing information" do
+      agents_job.write_cpf_to_file(temp_dir, 13, 'people')
+
+      expect(Rails.logger).to have_received(:info).with("Processing CPF for people/13")
+      expect(Rails.logger).to have_received(:info).with("Wrote CPF XML to #{temp_dir}/SMITH_HENRYBRADFORD_people_13.CPF.xml")
+    end
+
+    context "when processing fails" do
+      before do
+        allow(agents_job).to receive(:get_archival_context_xml).and_raise(StandardError.new("API error"))
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "logs the error and continues" do
+        expect { agents_job.write_cpf_to_file(temp_dir, 13, 'people') }.not_to raise_error
+        expect(agents_job.instance_variable_get(:@errors)).to include("Unable to process CPF for people/13: API error")
+      end
+    end
+  end
+
+  describe "#process_all_cpf_files" do
+    let(:temp_dir) { 'tmp/test_processing' }
+
+    before do
+      FileUtils.mkdir_p(temp_dir)
+      agents_job.instance_variable_set(:@client, mock_client)
+      allow(mock_client).to receive(:get).with("agents/people", { query: { all_ids: true } }).and_return(agent_ids_response)
+      allow(mock_client).to receive(:get).with("/repositories/1/archival_contexts/people/13.xml").and_return(cpf_response)
+      allow(mock_client).to receive(:get).with("/repositories/1/archival_contexts/people/14.xml").and_return(cpf_response)
+      allow(mock_client).to receive(:get).with("/repositories/1/archival_contexts/people/15.xml").and_return(cpf_response)
+      allow(Rails.logger).to receive(:info)
+      allow(File).to receive(:write).and_call_original
+    end
+
+    after do
+      FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir)
+    end
+
+    it "processes all agents of specified type" do
+      processed_count = agents_job.process_all_cpf_files('people', temp_dir, chunk_size: 2, start_from: 0)
+
+      expect(processed_count).to eq(3)
+      expect(Rails.logger).to have_received(:info).with("Processing 3 people agents for CPF files (starting from 0)")
+    end
+
+    it "creates checkpoint file during processing" do
+      agents_job.process_all_cpf_files('people', temp_dir, chunk_size: 2, start_from: 0)
+
+      # Should create checkpoint after processing 2 agents (chunk_size: 2)
+      expect(File).to have_received(:write).with("#{temp_dir}/people_checkpoint.txt", 2)
+    end
+
+    it "cleans up checkpoint file on completion" do
+      allow(File).to receive(:delete)
+
+      agents_job.process_all_cpf_files('people', temp_dir, chunk_size: 2, start_from: 0)
+
+      expect(File).to have_received(:delete).with("#{temp_dir}/people_checkpoint.txt")
+    end
+
+    context "when resuming from checkpoint" do
+      before do
+        File.write("#{temp_dir}/people_checkpoint.txt", "1")
+      end
+
+      it "resumes from checkpoint position" do
+        processed_count = agents_job.process_all_cpf_files('people', temp_dir, chunk_size: 2, start_from: 0)
+
+        expect(Rails.logger).to have_received(:info).with("Resuming from checkpoint: 1")
+        expect(processed_count).to eq(2) # Only processes remaining agents (14, 15)
+      end
+    end
+
+    context "with unknown agent type" do
+      it "raises an error" do
+        expect { agents_job.process_all_cpf_files('croutons', temp_dir) }.to raise_error("Unknown agent type: croutons")
+      end
+    end
+  end
+
+  describe "convenience processing methods" do
+    let(:temp_dir) { 'tmp/test_convenience' }
+
+    before do
+      FileUtils.mkdir_p(temp_dir)
+    end
+
+    after do
+      FileUtils.rm_rf(temp_dir) if Dir.exist?(temp_dir)
+    end
+
+    describe "#process_all_person_cpf_files" do
+      it "calls generic method with people type" do
+        expect(agents_job).to receive(:process_all_cpf_files).with('people', temp_dir, chunk_size: 500, start_from: 0)
+        agents_job.process_all_person_cpf_files(temp_dir)
+      end
+    end
+
+    describe "#process_all_family_cpf_files" do
+      it "calls generic method with families type" do
+        expect(agents_job).to receive(:process_all_cpf_files).with('families', temp_dir, chunk_size: 500, start_from: 0)
+        agents_job.process_all_family_cpf_files(temp_dir)
+      end
+    end
+
+    describe "#process_all_corporate_entity_cpf_files" do
+      it "calls generic method with corporate_entities type" do
+        expect(agents_job).to receive(:process_all_cpf_files).with('corporate_entities', temp_dir, chunk_size: 500, start_from: 0)
+        agents_job.process_all_corporate_entity_cpf_files(temp_dir)
+      end
+    end
+  end
+
+  describe "#generate_cpf_filename" do
+    let(:doc_with_name_parts) do
+      Nokogiri::XML(cpf_xml_body)
+    end
+
+    let(:doc_without_names) do
+      Nokogiri::XML(<<~XML)
+        <?xml version="1.0" encoding="UTF-8"?>
+        <eac-cpf xmlns="urn:isbn:1-931666-33-4">
+          <control>
+            <recordId>TESTRECORD123</recordId>
+          </control>
+          <cpfDescription>
+            <identity>
+              <entityId>TESTENTITY456</entityId>
+            </identity>
+          </cpfDescription>
+        </eac-cpf>
+      XML
+    end
+
+    it "generates filename from surname and forename" do
+      filename = agents_job.send(:generate_cpf_filename, doc_with_name_parts, 13, 'people')
+      expect(filename).to eq('SMITH_HENRYBRADFORD_people_13')
+    end
+
+    it "falls back to entityId when name parts not found" do
+      filename = agents_job.send(:generate_cpf_filename, doc_without_names, 13, 'families')
+      expect(filename).to eq('families_13')
+    end
+
+    it "falls back to agent_id when no identifiers found" do
+      empty_doc = Nokogiri::XML('<root></root>')
+      filename = agents_job.send(:generate_cpf_filename, empty_doc, 13, 'people')
+      expect(filename).to eq('people_13')
+    end
+  end
+
+  describe "#handle" do
+    let(:data_set) { DataSet.new(category: "Agents_export") }
+
+    before do
+      allow(agents_job).to receive(:aspace_login).and_return(mock_client)
+    end
+
+    it "processes the data set and sets report time" do
+      result = agents_job.handle(data_set: data_set)
+
+      expect(result.data).to eq("Agents successfully exported.")
+      expect(result.report_time).to be_within(1.second).of(Time.zone.now)
+    end
+  end
+
+  describe "#report" do
+    context "when no errors occurred" do
+      it "returns success message" do
+        expect(agents_job.report).to eq("Agents successfully exported.")
+      end
+    end
+
+    context "when errors occurred" do
+      before do
+        agents_job.instance_variable_set(:@errors, ["Error 1", "Error 2"])
+      end
+
+      it "returns joined error messages" do
+        expect(agents_job.report).to eq("Error 1, Error 2")
+      end
+    end
+  end
+end


### PR DESCRIPTION
As a first step create a job to call agents from aspace (people, families, corporate entities)
Use the global repository to retrieve ids and the archival context to build the CPF.xml file
Concat the file name to be surname_forename_agent_type(e.g people, families, corporate_enitities)_agent_id (per @regineheberlein 's review)
Use chunk_size of 500 records at a time and process in batches
Create a checkpoint file to track down the progress of the agent processing. Can resume from interruptions using this checkpoint. Log the process and failures
Call the api using a rate limiting: 2 seconds per chunk, 0.05s every 20 records
This job as a first step saved the cpf xml processed files in tmp.


related to #964