### PR TITLE
Configure the github user

### DIFF
--- a/app/models/aspace_version_control/git_lab.rb
+++ b/app/models/aspace_version_control/git_lab.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AspaceVersionControl
-  # This class is responsible for committing EADs to GitLab for version control
+  # This class is responsible for committing EADs and EACs to GitLab for version control
   class GitLab
     def initialize(repo_path: nil)
       @custom_repo_path = repo_path
@@ -16,6 +16,7 @@ module AspaceVersionControl
     end
 
     def commit_eacs_to_git(path:)
+      git_config
       update(path:)
       return unless changes?(path:)
       add(path:)
@@ -33,8 +34,7 @@ module AspaceVersionControl
     end
 
     def git_config
-      @repo.config('user.name', 'scuaAPI')
-      @repo.config('user.email', 'heberlen@princeton.edu')
+      configure_git_user(repo)
     end
 
     def current_repo_path
@@ -78,6 +78,13 @@ module AspaceVersionControl
 
     def self.config
       @config ||= Rails.application.config.aspace
+    end
+
+    private
+
+    def configure_git_user(repo)
+      repo.config('user.name', 'scuaAPI')
+      repo.config('user.email', 'heberlen@princeton.edu')
     end
   end
 end

--- a/spec/models/aspace_version_control/git_lab_spec.rb
+++ b/spec/models/aspace_version_control/git_lab_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe AspaceVersionControl::GitLab do
           allow(eacs_repo).to receive(:commit).and_call_original
           allow(eacs_repo).to receive(:push).and_call_original
           allow(eacs_repo).to receive(:checkout).and_return("Updated 0 paths from")
+          allow(eacs_repo).to receive(:config).and_return(nil)
 
           custom_git_lab.commit_eacs_to_git(path: 'eacs')
 
@@ -179,6 +180,7 @@ RSpec.describe AspaceVersionControl::GitLab do
           # rubocop:enable Layout/LineLength:
           allow(eacs_repo).to receive(:push).and_return(nil)
           allow(eacs_repo).to receive(:checkout).and_return("Updated 0 paths from")
+          allow(eacs_repo).to receive(:config).and_return(nil)
 
           custom_git_lab.commit_eacs_to_git(path: 'eacs')
 


### PR DESCRIPTION
Configure git only when working with agent eacs
For eads continue using the current princeton ansible approach

If we want to apply it to all git operations both for eads and eacs
a good approach would be to configure_git_user in the repo method
ensuring the git configuration is set before any git operations