### PR TITLE
Use the whenever syntax due to a parse error of 1#1

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -90,8 +90,8 @@ every 1.month, at: ['9:00 pm'], roles: [:cron_prod2] do
   rake "lib_jobs:send_eads"
 end
 
-# Run every 1st Monday of the month at 10pm UTC
-every '0 22 * * 1#1', roles: [:cron_prod2] do
+# Run every month at 10pm UTC
+every :month, at: '10:00 pm', roles: [:cron_prod2] do
   rake "lib_jobs:pull_and_send_agents"
 end
 


### PR DESCRIPTION
Use the whenever syntax due to a parse error of 1#1 in the previous syntax
Run the job every month at 10pm UTC

it generates: `0 22 1 * * /bin/bash -l -c 'cd /opt/lib-jobs/releases/20251013141556 && RAILS_ENV=production bundle exec rake lib_jobs:pull_and_send_agents --silent >> /opt/lib-jobs/shared/tmp/cron_log.log 2>&1'`

closes  #979