### PR TITLE
Remove foreman from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'devise', '>= 4.6.0'
 gem 'ed25519', '~> 1.3'
 gem 'faraday', '~> 2.7'
 gem "flipflop", git: "https://github.com/voormedia/flipflop.git", ref: "0d70d8e33483a9c0282ed8d6bca9c5ccd61e61e8"
-gem 'foreman'
 gem 'git'
 gem "health-monitor-rails"
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,6 @@ GEM
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
-    foreman (0.88.1)
     git (2.3.3)
       activesupport (>= 5.0)
       addressable (~> 2.8)
@@ -550,7 +549,6 @@ DEPENDENCIES
   factory_bot_rails
   faraday (~> 2.7)
   flipflop!
-  foreman
   git
   health-monitor-rails
   honeybadger


### PR DESCRIPTION
Its own docs say not to include it in a Gemfile: https://github.com/ddollar/foreman?tab=readme-ov-file#installation