### PR TITLE
Revert "Toggle off newly cataloged records job."

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -44,10 +44,9 @@ every 1.day, at: '1:00 pm', roles: [:cron_prod2] do # The server is in UTC, so t
 end
 
 # Run on production at 6am EST or 7am EDT
-# Removing per MZ; Turn back on 4/27/2026
-# every :monday, at: '11:00 am', roles: [:cron_prod2] do
-#  rake "lib_jobs:process_newly_cataloged_records"
-# end
+every :monday, at: '11:00 am', roles: [:cron_prod2] do
+  rake "lib_jobs:process_newly_cataloged_records"
+end
 
 # Run on production Tuesday at 9:30am EST or 10:30am EDT (after the records are published on Sunday)
 every :tuesday, at: '2:30 pm', roles: [:cron_prod2] do # The server is in UTC, so this is 14:30 UTC


### PR DESCRIPTION
This reverts commit 5000cb9ba5c295dca8e7902e94bb79a837eda428. It will re-enable the LC Slips weekly job. 