### PR TITLE
TMAS: rollback airtable writes in cases where there was some kind of error

### DIFF
--- a/app/models/tmas_gate_counts/airtable_client.rb
+++ b/app/models/tmas_gate_counts/airtable_client.rb
@@ -7,9 +7,10 @@ module TMASGateCounts
       @env = env
     end
 
-    def call(request_class: Net::HTTP::Post, json:)
+    def call(request_class: Net::HTTP::Post, json: nil, uri_builder: AirtableClient.default_uri_builder)
+      uri = uri_builder.call(BASE_ID, TABLE_ID)
       request = request_class.new(uri, { 'Authorization' => "Bearer #{env['PEOPLE_COUNTER_AIRTABLE_TOKEN']}", 'Content-Type' => 'application/json' })
-      request.body = json
+      request.body = json if json
       response = Net::HTTP.start(uri.hostname, uri.port, { use_ssl: true }) do |http|
         http.request(request)
       end
@@ -23,15 +24,20 @@ module TMASGateCounts
       end
     end
 
+    def self.default_uri_builder
+      ->(base_id, table_id) { URI.parse("https://api.airtable.com/v0/#{base_id}/#{table_id}") }
+    end
+
+    def self.delete_uri_builder(ids)
+      query_string = ids.map { |id| "records[]=#{id}" }.join('&')
+      ->(base_id, table_id) { URI.parse("https://api.airtable.com/v0/#{base_id}/#{table_id}?#{query_string}") }
+    end
+
     BASE_ID = 'appAqHrmsuH7VsZOB'
     TABLE_ID = 'tblLkWS3cZh8YqlgN'
 
     private
 
     attr_reader :env
-
-    def uri
-      @uri ||= URI.parse("https://api.airtable.com/v0/#{BASE_ID}/#{TABLE_ID}")
-    end
   end
 end

--- a/app/models/tmas_gate_counts/job.rb
+++ b/app/models/tmas_gate_counts/job.rb
@@ -20,11 +20,15 @@ module TMASGateCounts
                          responses.each do |response|
                            to_airtable_hashes
                              .call(response)
-                             .bind { |batches| batches.each { |batch| airtable_client.call(json: { records: batch }.to_json) } }
+                             .bind { send_batches_to_airtable.call(batches) }
                          end
                        end
 
       data_set
+    end
+
+    def send_batches_to_airtable
+      SendBatchesToAirtable.new(airtable_client)
     end
 
     def airtable_client

--- a/app/models/tmas_gate_counts/send_batches_to_airtable.rb
+++ b/app/models/tmas_gate_counts/send_batches_to_airtable.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module TMASGateCounts
+  # This class is responsible for sending batches of gate count data to Airtable,
+  # and rolling back to a clean state if there was a problem
+  class SendBatchesToAirtable
+    include Dry::Monads[:result]
+
+    def initialize(client)
+      @client = client
+    end
+
+    def call(batches)
+      ids = batches.reduce([]) do |accumulator, batch|
+        response = client.call(json: batch)
+        case response
+        in Success
+          accumulator + JSON.parse(response.value!, symbolize_names: true)[:records]&.map { it[:id] }
+        in Failure
+          rollback(accumulator)
+          return response
+        end
+      end
+      Success(ids)
+    end
+
+      private
+
+    attr_reader :client
+
+    # Delete all of the provided IDs, so that Airtable is not left in a situation of
+    # partial data
+    def rollback(ids)
+      # Airtable can only delete 10 ids at a time
+      ids.each_slice(10) do |id_batch|
+        client.call(
+      request_class: Net::HTTP::Delete,
+      uri_builder: TMASGateCounts::AirtableClient.delete_uri_builder(id_batch)
+    )
+      end
+    end
+  end
+end

--- a/spec/models/tmas_gate_counts/send_batches_to_airtable_spec.rb
+++ b/spec/models/tmas_gate_counts/send_batches_to_airtable_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe TMASGateCounts::SendBatchesToAirtable do
+  it 'can send batches to airtable' do
+    batches = ["batch 1", "batch 2"]
+    client = instance_double(TMASGateCounts::AirtableClient, call: Success('{"records":[{"id": "123"}]}'))
+
+    described_class.new(client).call(batches)
+
+    expect(client).to have_received(:call).with(json: "batch 1")
+    expect(client).to have_received(:call).with(json: "batch 2")
+  end
+
+  it 'reports the ids from Airtable' do
+    batches = ["batch 1", "batch 2"]
+    client = instance_double(TMASGateCounts::AirtableClient)
+    allow(client).to receive(:call).and_return(
+        Success('{"records":[{"id": "id 1"}]}'),
+        Success('{"records":[{"id": "id 2"}]}')
+      )
+
+    result = described_class.new(client).call(batches)
+
+    expect(result).to eq(Success(["id 1", "id 2"]))
+  end
+
+  it 'rolls back and stops on failure' do
+    batches = ["batch 1", "batch 2", 'batch 3']
+    client = instance_double(TMASGateCounts::AirtableClient)
+    allow(client).to receive(:call).with(json: 'batch 1').and_return(Success('{"records":[{"id": "id1"}]}'))
+    allow(client).to receive(:call).with(json: 'batch 2').and_return(Failure())
+    allow(client).to receive(:call).with(request_class: Net::HTTP::Delete, uri_builder: kind_of(Proc))
+
+    result = described_class.new(client).call(batches)
+
+    # We send batch 1 and 2 to the client, but not batch 3 since a previous batch failed
+    expect(client).to have_received(:call).with(json: 'batch 1')
+    expect(client).to have_received(:call).with(json: 'batch 2')
+
+    # We roll back the ids that have previously succeeded
+    expect(client).to have_received(:call).with(
+        request_class: Net::HTTP::Delete,
+        uri_builder: valid_delete_uri_builder
+      )
+
+    # We return Failure
+    expect(result).to be_failure
+  end
+
+  def valid_delete_uri_builder
+    satisfy do |builder|
+      builder.call('base', 'table') == URI.parse('https://api.airtable.com/v0/base/table?records[]=id1')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 require "webmock/rspec"
 require "simplecov"
 require 'database_cleaner/active_record'
+require 'dry-monads'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [
@@ -124,3 +125,5 @@ end
 
 WebMock.disable_net_connect!(allow_localhost: true,
                              allow: "chromedriver.storage.googleapis.com")
+
+Dry::Monads.load_extensions(:rspec)


### PR DESCRIPTION
This allows us to avoid situations in which data for some locations/hours ends up in Airtable and others don't

Helps with #1009