### PR TITLE
TMAS: Post counts to Airtable atomically by day

### DIFF
--- a/app/models/tmas_gate_counts.rb
+++ b/app/models/tmas_gate_counts.rb
@@ -10,4 +10,6 @@ module TMASGateCounts
     'MEND0000' => 'Mendel',
     'SLES0000' => 'Stokes Library'
   }.freeze
+
+  PRINCETON_TIMEZONE = ActiveSupport::TimeZone.new('Eastern Time (US & Canada)')
 end

--- a/app/models/tmas_gate_counts/fetch_tmas_counts.rb
+++ b/app/models/tmas_gate_counts/fetch_tmas_counts.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module TMASGateCounts
+  # This class is responsible for fetching gate counts from the TMAS system
+  # for all the desired days and locations
   class FetchTMASCounts
     include Dry::Monads[:result]
 
@@ -8,19 +10,12 @@ module TMASGateCounts
       @client = client
     end
 
-    # Returns Success([String]) or Failure
-    def call(start_date:, end_date: 1.day.ago, locations: TMAS_LOCATIONS.keys)
-      responses = Traverse.new.call(locations) { |location| client.fetch_data(date: start_date, location:) }
-      if responses.success && start_date < end_date
-        responses.and call(
-            start_date: start_date + 1.day,
-            end_date:,
-            locations:
-          ) do |x, y|
-            x + y
-          end
-      else
-        responses
+    # Yields a Success([String]) for each day's statistics (or Failure() if there was a problem)
+    def call(start_date:, end_date: PRINCETON_TIMEZONE.yesterday, locations: TMAS_LOCATIONS.keys)
+      (start_date..end_date).each do |date|
+        response = Traverse.new.call(locations) { |location| client.fetch_data(date:, location:) }
+        yield response
+        break if response.failure?
       end
     end
 

--- a/app/models/tmas_gate_counts/hourly_summary.rb
+++ b/app/models/tmas_gate_counts/hourly_summary.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-PRINCETON_TIMEZONE = ActiveSupport::TimeZone.new('Eastern Time (US & Canada)')
-
 module TMASGateCounts
   # This struct represents an hourly summary of gate counts from a single sensor (could be IN or OUT sensor)
   HourlySummary = Struct.new(:location, :time, :count) do

--- a/app/models/tmas_gate_counts/job.rb
+++ b/app/models/tmas_gate_counts/job.rb
@@ -15,14 +15,15 @@ module TMASGateCounts
     private
 
     def handle(data_set:)
-      fetch_tmas_counts.call(start_date:)
-                       .bind do |responses|
-                         responses.each do |response|
-                           to_airtable_hashes
-                             .call(response)
-                             .bind { send_batches_to_airtable.call(batches) }
-                         end
-                       end
+      fetch_tmas_counts.call(start_date:) do |response|
+        response
+          .bind { |branches| Traverse.new.call(branches) { |branch| to_airtable_hashes.call(branch) } }
+          # The Airtable API only can handle 10 records at a time
+          .fmap { |all_data| all_data.flatten.each_slice(10).map { { records: it }.to_json } }
+          .bind { |batches| send_batches_to_airtable.call(batches) }
+        # .bind { update next day to process }
+        # .or { handle the failure, no matter where in the process it came from, break }
+      end
 
       data_set
     end

--- a/app/models/tmas_gate_counts/to_airtable_hashes.rb
+++ b/app/models/tmas_gate_counts/to_airtable_hashes.rb
@@ -11,9 +11,6 @@ module TMASGateCounts
       Success(
         in_summaries.zip(out_summaries)
           .map { |summaries| CombineSensorData.new.call(summaries) }
-          # The Airtable API can only handle 10 records at once, so
-          # we group our JSON into chunks of 10 records
-          .then { |summaries| summaries.each_slice(10).to_a }
       )
     end
 

--- a/spec/models/tmas_gate_counts/fetch_tmas_counts_spec.rb
+++ b/spec/models/tmas_gate_counts/fetch_tmas_counts_spec.rb
@@ -15,14 +15,21 @@ RSpec.describe TMASGateCounts::FetchTMASCounts do
         'https://www.smssoftware.net/tms/manTrafExp?fromDate=04/02/2026&toDate=04/02/2026&interval=60&hours=0&reqType=tds&apiKey=MY_KEY&locationId=mend0000'
       )
                         .to_return(status: 200, body: 'XML 2')
-    results = described_class
-              .new(client:)
-              .call(start_date: Date.parse('2026-04-01'), end_date: Date.parse('2026-04-02'), locations: ['mend0000'])
+    results = []
+
+    described_class
+      .new(client:)
+      .call(start_date: Date.parse('2026-04-01'), end_date: Date.parse('2026-04-02'), locations: ['mend0000']) do |result|
+        results << result
+      end
 
     expect(april_first_mock).to have_been_requested
     expect(april_second_mock).to have_been_requested
 
-    expect(results).to eq(Success(['XML 1', 'XML 2']))
+    expect(results).to eq([
+                            Success(['XML 1']),
+                            Success(['XML 2'])
+                          ])
   end
 
   it 'short-circuits and returns Failure if request does not go through' do
@@ -31,12 +38,17 @@ RSpec.describe TMASGateCounts::FetchTMASCounts do
         :get,
         'https://www.smssoftware.net/tms/manTrafExp?fromDate=04/01/2026&toDate=04/01/2026&interval=60&hours=0&reqType=tds&apiKey=MY_KEY&locationId=mend0000'
       ).to_return(status: 500)
-    results = described_class
-              .new(client:)
-              .call(start_date: Date.parse('2026-04-01'), end_date: Date.parse('2026-04-02'), locations: ['mend0000'])
+
+    results = []
+    described_class.new(client:)
+                   .call(start_date: Date.parse('2026-04-01'), end_date: Date.parse('2026-04-02'), locations: ['mend0000']) do |result|
+                     results << result
+                   end
 
     expect(april_first_mock).to have_been_requested
 
-    expect(results).to eq(Failure('Got response 500 from the TMAS API'))
+    expect(results).to eq([
+                            Failure('Got response 500 from the TMAS API')
+                          ])
   end
 end

--- a/spec/models/tmas_gate_counts/to_airtable_hashes_spec.rb
+++ b/spec/models/tmas_gate_counts/to_airtable_hashes_spec.rb
@@ -34,7 +34,7 @@ END_XML
 
 RSpec.describe TMASGateCounts::ToAirtableHashes do
   it 'converts xml to an array of hashes' do
-    expected = [[
+    expected = [
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T09:00:00-04:00', fldwUTBK3mvfpN3Y8: 9, fldat8beQUOCWvdjm: 7 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T10:00:00-04:00', fldwUTBK3mvfpN3Y8: 12, fldat8beQUOCWvdjm: 20 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T11:00:00-04:00', fldwUTBK3mvfpN3Y8: 6, fldat8beQUOCWvdjm: 27 } },
@@ -44,11 +44,10 @@ RSpec.describe TMASGateCounts::ToAirtableHashes do
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T15:00:00-04:00', fldwUTBK3mvfpN3Y8: 14, fldat8beQUOCWvdjm: 25 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T16:00:00-04:00', fldwUTBK3mvfpN3Y8: 13, fldat8beQUOCWvdjm: 19 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T17:00:00-04:00', fldwUTBK3mvfpN3Y8: 7, fldat8beQUOCWvdjm: 14 } },
-      { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T18:00:00-04:00', fldwUTBK3mvfpN3Y8: 9, fldat8beQUOCWvdjm: 20 } }
-    ], [
+      { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T18:00:00-04:00', fldwUTBK3mvfpN3Y8: 9, fldat8beQUOCWvdjm: 20 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T19:00:00-04:00', fldwUTBK3mvfpN3Y8: 4, fldat8beQUOCWvdjm: 19 } },
       { fields: { fld5OFSWCZzeQb1Dq: 'Architecture', fldemkioYkKtAfesm: '2026-04-15T20:00:00-04:00', fldwUTBK3mvfpN3Y8: 2, fldat8beQUOCWvdjm: 9 } }
-    ]]
+    ]
     expect(described_class.new.call(TMAS_XML).value!).to eq(expected)
   end
 end


### PR DESCRIPTION
Before this commit, we gathered data from TMAS about all days before posting anything to Airtable.

With this commit, we fetch and post each day separately, so the whole migration doesn't fail if one single day fails.

Helps with #1009