### PR TITLE
Use optional tokens in hanami routes

### DIFF
--- a/slices/library_databases/config/routes.rb
+++ b/slices/library_databases/config/routes.rb
@@ -2,7 +2,6 @@
 
 module LibraryDatabases
   class Routes < Hanami::Routes
-    get '/library-databases', to: 'index'
-    get '/library-databases.csv', to: 'index'
+    get '/library-databases(.:format)', to: 'index'
   end
 end

--- a/slices/library_events/config/routes.rb
+++ b/slices/library_events/config/routes.rb
@@ -2,6 +2,6 @@
 
 module LibraryEvents
   class Routes < Hanami::Routes
-    get '/library-events', to: 'index'
+    get '/library-events(.:format)', to: 'index'
   end
 end


### PR DESCRIPTION
Hanami supports optional tokens in routes, so we can match /library-events and /library-events.csv with a single route line.

See https://github.com/hanami/hanami-router#string-matching-with-optional-tokens