### PR TITLE
Add the lux header to Hanami pages

### DIFF
--- a/config/initializers/load_hanami.rb
+++ b/config/initializers/load_hanami.rb
@@ -18,9 +18,24 @@ module LibJobsHanami
     prepare_container do |container|
       container.autoloader.ignore('app')
     end
+
+    config.actions.content_security_policy[:script_src] = "'self' 'nonce' https: 'unsafe-eval'"
+    config.actions.finalize!(config)
   end
 
   class Action < Hanami::Action
+  end
+
+  module Views
+    class Context < Hanami::View::Context
+      def library_header_menu_items
+        Shared::LibraryHeaderMenuItems.new(env: request.env).call
+      end
+
+      def content_security_policy_nonce
+        request.env['hanami.content_security_policy_nonce']
+      end
+    end
   end
 end
 

--- a/slices/open_marc_records/views/index.rb
+++ b/slices/open_marc_records/views/index.rb
@@ -3,6 +3,7 @@ module OpenMarcRecords
   module Views
     class Index < Hanami::View
       include Deps["repos.marc_files"]
+      Shared::UseAppLayout.new.call(config)
 
       expose :files do
         marc_files.list

--- a/slices/recent_job_statuses/views/index.rb
+++ b/slices/recent_job_statuses/views/index.rb
@@ -2,6 +2,8 @@
 module RecentJobStatuses
   module Views
     class Index < Hanami::View
+      Shared::UseAppLayout.new.call(config)
+
       expose :statuses do
         RecentJobStatus.all
       end

--- a/slices/shared/library_header_menu_items.rb
+++ b/slices/shared/library_header_menu_items.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Shared
   class LibraryHeaderMenuItems
-    def initialize(env: request.env)
+    def initialize(env:)
       @env = env
     end
 

--- a/slices/shared/templates/layouts/app.html.erb
+++ b/slices/shared/templates/layouts/app.html.erb
@@ -1,0 +1,33 @@
+<html lang="en">
+  <head>
+    <%# nosemgrep -- content_security_policy_nonce is not controlled by the user %>
+    <script type="importmap" nonce="<%= content_security_policy_nonce %>">
+        {
+            "imports": {
+                "vue": "https://unpkg.com/vue@3.5.40/dist/vue.esm-browser.prod.js",
+                "lux-design-system": "https://unpkg.com/lux-design-system@7.7.1/dist/lux-styleguidist.mjs"
+            }
+        }
+    </script>
+    <%# nosemgrep -- content_security_policy_nonce is not controlled by the user %>
+    <script type="module" nonce="<%= content_security_policy_nonce %>">
+        import { createApp } from 'vue';
+        import lux from 'lux-design-system';
+
+        const app = createApp({});
+        app.use(lux)
+        .mount('.lux');
+    </script>
+    <link rel="stylesheet" href="https://unpkg.com/lux-design-system@7.7.1/dist/style.css" />
+  </head>
+  <body>
+    <header class="lux">
+        <lux-library-header app-name="Lib Jobs" app-url="/" theme="dark" max-width="inherit">
+            <lux-menu-bar type="main-menu" :menu-items="<%= library_header_menu_items %>"></lux-menu-bar>
+        </lux-library-header>
+    </header>
+
+
+    <%= yield %>
+  </body>
+</html>

--- a/slices/shared/use_app_layout.rb
+++ b/slices/shared/use_app_layout.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Shared
+  # This class is responsible for configuring a view to use the shared app layout
+  class UseAppLayout
+    def call(config)
+      config.paths.push Hanami::View::Path.new(Shared::Slice.config.root.join('templates'))
+      config.layout = 'app'
+    end
+  end
+end


### PR DESCRIPTION
Adds the header to the Open Marc Records and Recent Job Statuses pages.  This involved:

* Configuring Hanami's Content Security Policy to allow Lux
* Adding a new slice called `shared` for shared logic and visuals
* Adding a new layout to the `shared` slice
* Adding a new view context with all the helpers that are required by the layout
* Adding a class that configures a view to use the layout