### PR TITLE
Ensure that all slices use the same mailer SMTP configuration

### DIFF
--- a/config/initializers/load_hanami.rb
+++ b/config/initializers/load_hanami.rb
@@ -21,6 +21,8 @@ module LibJobsHanami
 
     config.actions.content_security_policy[:script_src] = "'self' 'nonce' https: 'unsafe-eval'"
     config.actions.finalize!(config)
+
+    config.shared_app_component_keys += ['mailers.delivery_method']
   end
 
   class Action < Hanami::Action


### PR DESCRIPTION
Before this change, production gets the test delivery method, rather than lib-ponyexpr!

```
RAILS_ENV=production SECRET_KEY_BASE=hello bundle exec rails c
> AlmaBibNorm::Slice['mailers.delivery_method']
=> #<Hanami::Mailer::Delivery::Test:0x000000012557b8d8>
```

With this change, we get the expected delivery method:

```
> AlmaBibNorm::Slice['mailers.delivery_method']
=> #<Hanami::Mailer::Delivery::SMTP:0x000000012461a088 @options={address: "lib-ponyexpr-prod.princeton.edu", enable_starttls: false}>
```

[See documentation for](https://hanakai.org/learn/hanami/v3.0/app/slices#standard-app-components) `config.shared_app_component_keys`