### PR TITLE
Separate Hanami.boot into its own initializer

### DIFF
--- a/config/app.rb
+++ b/config/app.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'hanami'
+require 'hanami/view'
+
+# Hanami and Rails each have their own implementation of html_safe.
+# Various Rails behavior breaks if it has to use Hanami's html_safe
+# behavior (e.g. form helper tags), so we make sure that the Rails
+# html_safe is used.  See
+# https://discourse.hanakai.org/t/rails-and-hanami-view-dont-get-along/1122
+Hanami::View::HTML::StringExtensions.class_eval do
+  def html_safe = ActiveSupport::SafeBuffer.new(self)
+end
+
+# The configuration and coordination of Lib-jobs Hanami application.
+# See config/application for the Lib-jobs Rails application.
+module LibJobsHanami
+  class App < Hanami::App
+    prepare_container do |container|
+      container.autoloader.ignore('app')
+    end
+
+    config.actions.content_security_policy[:script_src] = "'self' 'nonce' https: 'unsafe-eval'"
+    config.actions.finalize!(config)
+
+    config.inflections do |inflections|
+      inflections.acronym 'TMAS'
+    end
+
+    config.shared_app_component_keys += ['mailers.delivery_method']
+  end
+
+  class Action < Hanami::Action
+  end
+
+  module Views
+    class Context < Hanami::View::Context
+      def library_header_menu_items
+        Shared::LibraryHeaderMenuItems.new(env: request.env).call
+      end
+
+      def content_security_policy_nonce
+        request.env['hanami.content_security_policy_nonce']
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ Bundler.require(*Rails.groups)
 require 'zip'
 
 module IlsApps
+  # The configuration and coordination of Lib-jobs Rails application.
+  # See config/app for the Lib-jobs Hanami application.
   class Application < Rails::Application
     config.flipflop.dashboard_access_filter = :verify_admin!
 

--- a/config/initializers/load_hanami.rb
+++ b/config/initializers/load_hanami.rb
@@ -1,48 +1,4 @@
 # frozen_string_literal: true
-require 'hanami'
-require 'hanami/view'
 
-# Hanami and Rails each have their own implementation of html_safe.
-# Various Rails behavior breaks if it has to use Hanami's html_safe
-# behavior (e.g. form helper tags), so we make sure that the Rails
-# html_safe is used.  See
-# https://discourse.hanakai.org/t/rails-and-hanami-view-dont-get-along/1122
-Hanami::View::HTML::StringExtensions.class_eval do
-  def html_safe
-    ActiveSupport::SafeBuffer.new(self)
-  end
-end
-
-module LibJobsHanami
-  class App < Hanami::App
-    prepare_container do |container|
-      container.autoloader.ignore('app')
-    end
-
-    config.actions.content_security_policy[:script_src] = "'self' 'nonce' https: 'unsafe-eval'"
-    config.actions.finalize!(config)
-
-    config.inflections do |inflections|
-      inflections.acronym 'TMAS'
-    end
-
-    config.shared_app_component_keys += ['mailers.delivery_method']
-  end
-
-  class Action < Hanami::Action
-  end
-
-  module Views
-    class Context < Hanami::View::Context
-      def library_header_menu_items
-        Shared::LibraryHeaderMenuItems.new(env: request.env).call
-      end
-
-      def content_security_policy_nonce
-        request.env['hanami.content_security_policy_nonce']
-      end
-    end
-  end
-end
-
+require_relative '../app'
 Hanami.boot


### PR DESCRIPTION
This recommendation came from @timriley -- thank you!  See https://github.com/hanami/hanami-cli/issues/438#issuecomment-5139202560

`Hanami.boot` eagerly loads/initializes all of our Hanami components. This is great for production, so that all of the components are ready to be used!  But for other use cases -- e.g. running a simple command locally -- we could use the faster `Hanami.prepare` and lazily load components when they are needed.  This PR separates `Hanami.boot` into its own file so we that we can choose `Hanami.prepare` or `Hanami.boot` as appropriate.

Eventually, it would be nice to introduce something like the following to the initializer, but it currently gives me test failures from a Rails model that injects Hanami depenencies:

```
if Rails.env.local?
  Hanami.prepare
else
  Hanami.boot
end
```

As an added bonus, since we now have our Hanami App defined at the expected config/app.rb path, we can start using the Hanami generators (e.g. `hanami generate action --slice library_events events.show`)