### PR TITLE
Fix regression in Traverse class

### DIFF
--- a/slices/shared/traverse.rb
+++ b/slices/shared/traverse.rb
@@ -12,8 +12,8 @@ module Shared
       array.reduce(Success([])) do |accumulator, el|
         result = yield(el)
         case result
-        in Success(Object => value)
-          accumulator.fmap { |accumulated| accumulated.push(value) }
+        in Success
+          accumulator.fmap { |accumulated| accumulated.push(result.value!) }
         else
           break result
         end

--- a/spec/slices/shared/traverse_spec.rb
+++ b/spec/slices/shared/traverse_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe Shared::Traverse do
     expect(result).to eq(Failure('Found a value higher than 1!'))
     expect(processed).to eq([1, 2])
   end
+  it 'can create an array of arrays' do
+    my_array = [1, 2, 3]
+    result = described_class.new.call(my_array) { Success(['hello', 'from', it]) }
+    expect(result).to eq(Success([
+                                   ['hello', 'from', 1],
+                                   ['hello', 'from', 2],
+                                   ['hello', 'from', 3]
+                                 ]))
+  end
+  it 'can create an array of hashes' do
+    my_array = [1, 2, 3]
+    result = described_class.new.call(my_array) { Success({ my_favorite: it }) }
+    expect(result).to eq(Success([
+                                   { my_favorite: 1 },
+                                   { my_favorite: 2 },
+                                   { my_favorite: 3 }
+                                 ]))
+  end
 end


### PR DESCRIPTION
In #1168, I tried to simplify this class by using Ruby's variable binding feature (rather than calling value! on the monad).  However, this did not work for arrays, since arrays need a star at the beginning of the variable (see https://hanakai.org/learn/dry/dry-monads/v1.8/pattern-matching#matching-array-values).

...and then when I added the star, it stopped working for hashes, so let's go back to the original implementation.

The effect of this regression was that we only ever pushed data from the Architecture library's sensor to Airtable. 😅 